### PR TITLE
feat: generic webhook alerter — Slack, Discord, Teams, any URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,23 @@ $ scherlok watch
 ### 3. Alert — Slack, CI/CD, or both
 
 ```bash
-# Slack alerts
-scherlok watch --slack https://hooks.slack.com/services/...
+# Slack
+scherlok watch --webhook https://hooks.slack.com/services/...
+
+# Discord
+scherlok watch --webhook https://discord.com/api/webhooks/...
+
+# Microsoft Teams
+scherlok watch --webhook https://outlook.office.com/webhook/...
+
+# Any endpoint (generic JSON payload)
+scherlok watch --webhook https://my-api.com/alerts
 
 # CI/CD gate (fails pipeline on CRITICAL)
 scherlok watch --exit-code --fail-on critical
 ```
+
+Auto-detects Slack, Discord, and Teams from the URL and formats the payload accordingly. Any other URL receives a generic JSON payload.
 
 ## CI/CD Integration
 
@@ -169,7 +180,7 @@ scherlok config --store az://my-container/scherlok/profiles.db
 ```
 scherlok connect <url>          Connect to a database
 scherlok investigate            Profile all tables (learn patterns)
-scherlok watch                  Detect anomalies and alert
+scherlok watch [-w <url>]       Detect anomalies and alert
 scherlok status                 Quick health dashboard
 scherlok report                 Detailed profile summary
 scherlok history [--days N]     Timeline of past anomalies

--- a/src/scherlok/alerter/webhook.py
+++ b/src/scherlok/alerter/webhook.py
@@ -1,0 +1,127 @@
+"""Generic webhook alerter — sends anomalies to any HTTP endpoint.
+
+Covers Slack, Teams, Discord, PagerDuty, Opsgenie, and any custom URL.
+Auto-detects the platform from the URL and formats the payload accordingly.
+Falls back to a generic JSON payload for unknown endpoints.
+"""
+
+import logging
+
+import requests
+
+from scherlok.detector.severity import Severity
+
+logger = logging.getLogger(__name__)
+
+SEVERITY_EMOJI = {
+    Severity.INFO: "ℹ️",
+    Severity.WARNING: "⚠️",
+    Severity.CRITICAL: "🔴",
+}
+
+
+def _format_text(anomalies: list[dict]) -> str:
+    """Format anomalies as plain text lines."""
+    lines = ["Scherlok Data Quality Alert", ""]
+    for a in anomalies:
+        emoji = SEVERITY_EMOJI.get(a["severity"], "")
+        lines.append(f"{emoji} [{a['severity'].value}] {a['table']} — {a['message']}")
+    return "\n".join(lines)
+
+
+def _payload_slack(anomalies: list[dict]) -> dict:
+    """Slack Block Kit payload."""
+    blocks = [
+        {"type": "header", "text": {"type": "plain_text", "text": "Scherlok Data Quality Alert"}},
+    ]
+    for a in anomalies:
+        emoji = {
+            Severity.INFO: ":information_source:",
+            Severity.WARNING: ":warning:",
+            Severity.CRITICAL: ":rotating_light:",
+        }.get(a["severity"], "")
+        blocks.append({
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"{emoji} *[{a['severity'].value}]* `{a['table']}`\n{a['message']}",
+            },
+        })
+    return {"blocks": blocks}
+
+
+def _payload_discord(anomalies: list[dict]) -> dict:
+    """Discord webhook payload."""
+    return {"content": _format_text(anomalies)}
+
+
+def _payload_teams(anomalies: list[dict]) -> dict:
+    """Microsoft Teams Incoming Webhook payload."""
+    return {
+        "@type": "MessageCard",
+        "summary": "Scherlok Data Quality Alert",
+        "themeColor": "FF0000" if any(
+            a["severity"] == Severity.CRITICAL for a in anomalies
+        ) else "FFA500",
+        "title": "Scherlok Data Quality Alert",
+        "text": _format_text(anomalies).replace("\n", "<br>"),
+    }
+
+
+def _payload_generic(anomalies: list[dict]) -> dict:
+    """Generic JSON payload — works with any endpoint."""
+    return {
+        "source": "scherlok",
+        "summary": f"{len(anomalies)} anomalies detected",
+        "anomalies": [
+            {
+                "table": a["table"],
+                "type": a["type"],
+                "severity": a["severity"].value,
+                "message": a["message"],
+            }
+            for a in anomalies
+        ],
+    }
+
+
+def _detect_platform(url: str) -> str:
+    """Auto-detect platform from webhook URL."""
+    url_lower = url.lower()
+    if "hooks.slack.com" in url_lower or "slack" in url_lower:
+        return "slack"
+    if "discord.com/api/webhooks" in url_lower or "discordapp.com" in url_lower:
+        return "discord"
+    if "office.com" in url_lower or "teams" in url_lower:
+        return "teams"
+    return "generic"
+
+
+def send_webhook(url: str, anomalies: list[dict]) -> bool:
+    """Send anomalies to a webhook URL. Auto-detects platform format.
+
+    Returns True if the request succeeded (2xx status).
+    """
+    if not anomalies:
+        return True
+
+    platform = _detect_platform(url)
+    formatters = {
+        "slack": _payload_slack,
+        "discord": _payload_discord,
+        "teams": _payload_teams,
+        "generic": _payload_generic,
+    }
+    payload = formatters[platform](anomalies)
+
+    try:
+        resp = requests.post(url, json=payload, timeout=10)
+        ok = 200 <= resp.status_code < 300
+        if ok:
+            logger.info("Webhook sent to %s (%s)", platform, url[:50])
+        else:
+            logger.warning("Webhook %s returned %d", url[:50], resp.status_code)
+        return ok
+    except requests.RequestException as e:
+        logger.warning("Webhook failed for %s: %s", url[:50], e)
+        return False

--- a/src/scherlok/cli.py
+++ b/src/scherlok/cli.py
@@ -8,6 +8,7 @@ from rich.table import Table
 from scherlok import __version__
 from scherlok.alerter.console import print_anomalies, print_profile_summary
 from scherlok.alerter.exitcode import exit_code_for
+from scherlok.alerter.webhook import send_webhook
 from scherlok.config import ScherlokConfig
 from scherlok.connectors import get_connector
 from scherlok.detector.anomaly import detect_volume_anomalies
@@ -140,12 +141,18 @@ def investigate() -> None:
 
 
 @app.command()
-def watch() -> None:
+def watch(
+    webhook: str = typer.Option(
+        None, "--webhook", "-w",
+        help="Webhook URL to send alerts (auto-detects Slack, Discord, Teams).",
+    ),
+) -> None:
     """Compare current state vs stored profile. Detect anomalies.
 
     Example:
         scherlok watch
-        scherlok watch --slack https://hooks.slack.com/...
+        scherlok watch --webhook https://hooks.slack.com/...
+        scherlok watch -w https://discord.com/api/webhooks/...
     """
     connector = _get_connector_or_exit()
     cfg = ScherlokConfig.load()
@@ -215,6 +222,12 @@ def watch() -> None:
         if all_anomalies:
             store.save_anomalies(all_anomalies)
             print_anomalies(all_anomalies)
+            if webhook:
+                ok = send_webhook(webhook, all_anomalies)
+                if ok:
+                    console.print("[dim]Webhook sent.[/dim]")
+                else:
+                    console.print("[red]Webhook delivery failed.[/red]")
         else:
             console.print("[green]No anomalies detected.[/green]")
 

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,0 +1,102 @@
+"""Tests for the generic webhook alerter."""
+
+from unittest.mock import MagicMock, patch
+
+from scherlok.alerter.webhook import (
+    _detect_platform,
+    _payload_discord,
+    _payload_generic,
+    _payload_slack,
+    _payload_teams,
+    send_webhook,
+)
+from scherlok.detector.severity import Severity
+
+
+def _anomalies():
+    return [
+        {
+            "table": "orders", "type": "volume_drop",
+            "severity": Severity.CRITICAL, "message": "Row count dropped 52%",
+        },
+        {
+            "table": "users", "type": "null_increase",
+            "severity": Severity.WARNING, "message": "NULL rate 2% → 18%",
+        },
+    ]
+
+
+class TestDetectPlatform:
+    def test_slack(self):
+        assert _detect_platform("https://hooks.slack.com/services/T/B/x") == "slack"
+
+    def test_discord(self):
+        assert _detect_platform("https://discord.com/api/webhooks/123/abc") == "discord"
+
+    def test_teams(self):
+        url = "https://outlook.office.com/webhook/xxx"
+        assert _detect_platform(url) == "teams"
+
+    def test_generic(self):
+        assert _detect_platform("https://my-api.com/webhook") == "generic"
+
+
+class TestPayloadFormats:
+    def test_slack_has_blocks(self):
+        payload = _payload_slack(_anomalies())
+        assert "blocks" in payload
+        assert payload["blocks"][0]["type"] == "header"
+
+    def test_discord_has_content(self):
+        payload = _payload_discord(_anomalies())
+        assert "content" in payload
+        assert "Scherlok" in payload["content"]
+
+    def test_teams_has_messagcard(self):
+        payload = _payload_teams(_anomalies())
+        assert payload["@type"] == "MessageCard"
+        assert payload["themeColor"] == "FF0000"  # CRITICAL present
+
+    def test_teams_warning_color(self):
+        anomalies = [{
+            "table": "t", "type": "x",
+            "severity": Severity.WARNING, "message": "m",
+        }]
+        payload = _payload_teams(anomalies)
+        assert payload["themeColor"] == "FFA500"
+
+    def test_generic_has_anomalies_list(self):
+        payload = _payload_generic(_anomalies())
+        assert payload["source"] == "scherlok"
+        assert len(payload["anomalies"]) == 2
+        assert payload["anomalies"][0]["severity"] == "CRITICAL"
+
+
+class TestSendWebhook:
+    @patch("scherlok.alerter.webhook.requests.post")
+    def test_sends_and_returns_true(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200)
+        assert send_webhook("https://hooks.slack.com/x", _anomalies()) is True
+        mock_post.assert_called_once()
+
+    @patch("scherlok.alerter.webhook.requests.post")
+    def test_returns_false_on_error(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=500)
+        assert send_webhook("https://hooks.slack.com/x", _anomalies()) is False
+
+    @patch("scherlok.alerter.webhook.requests.post")
+    def test_returns_false_on_exception(self, mock_post):
+        import requests
+        mock_post.side_effect = requests.RequestException("timeout")
+        assert send_webhook("https://my-api.com/x", _anomalies()) is False
+
+    def test_empty_anomalies_returns_true(self):
+        assert send_webhook("https://any-url.com", []) is True
+
+    @patch("scherlok.alerter.webhook.requests.post")
+    def test_auto_detects_discord(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=204)
+        url = "https://discord.com/api/webhooks/123/abc"
+        assert send_webhook(url, _anomalies()) is True
+        payload = mock_post.call_args[1]["json"]
+        assert "content" in payload  # Discord format


### PR DESCRIPTION
## Summary
One flag, all platforms:
```bash
scherlok watch --webhook https://hooks.slack.com/...
scherlok watch -w https://discord.com/api/webhooks/...
scherlok watch -w https://outlook.office.com/webhook/...
scherlok watch -w https://my-api.com/alerts
```

Auto-detects Slack, Discord, Teams from URL. Generic JSON for everything else.

- 14 new tests (107 total)
- README updated