### PR TITLE
chore: OSS infra — issue templates, CHANGELOG, auto release notes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Something isn't working
+title: 'bug: '
+labels: bug
+---
+
+## Description
+
+<!-- Clear and concise description of what the bug is -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+<!-- What you expected to happen -->
+
+## Actual behavior
+
+<!-- What actually happened (include error messages, stack traces) -->
+
+## Environment
+
+- Scherlok version: <!-- output of `scherlok version` -->
+- Python version: <!-- output of `python --version` -->
+- OS: <!-- macOS / Linux / Windows + version -->
+- Database: <!-- PostgreSQL 16 / BigQuery / Snowflake -->
+
+## Additional context
+
+<!-- Logs, screenshots, related issues -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question / discussion
+    url: https://github.com/rbmuller/scherlok/discussions
+    about: Ask questions, share use cases, or discuss the project.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,26 @@
+---
+name: Feature request
+about: Suggest a new feature or improvement
+title: 'feat: '
+labels: enhancement
+---
+
+## Problem
+
+<!-- What problem does this feature solve? Why is it needed? -->
+
+## Proposed solution
+
+<!-- Describe the solution you'd like -->
+
+## Alternatives considered
+
+<!-- Other approaches you considered and why they don't fit -->
+
+## Use case
+
+<!-- Real-world scenario where this would help. Bonus: include sample data/code. -->
+
+## Additional context
+
+<!-- Mockups, references, related issues -->

--- a/.github/ISSUE_TEMPLATE/new_connector.md
+++ b/.github/ISSUE_TEMPLATE/new_connector.md
@@ -1,0 +1,44 @@
+---
+name: New connector
+about: Propose support for a new database / data warehouse
+title: 'feat: <database> connector'
+labels: enhancement, connector
+---
+
+## Database
+
+<!-- e.g. MySQL, DuckDB, Redshift, ClickHouse -->
+
+## Why this connector
+
+<!-- How widely used? Who would benefit? Any specific company/use case driving the request? -->
+
+## Connection string format
+
+<!-- Proposed scheme. Examples:
+- mysql://user:pass@host:3306/db
+- duckdb:///path/to/file.db
+- redshift://user:pass@host:5439/db
+-->
+
+## Authentication
+
+<!-- Username/password? Token? Service account? Env vars? -->
+
+## Required Python library
+
+<!-- e.g. pymysql, duckdb, redshift-connector. Include PyPI link. -->
+
+## Schema introspection
+
+<!-- How to list tables, columns, get row counts. Link to docs of INFORMATION_SCHEMA equivalent. -->
+
+## I'd like to
+
+- [ ] Implement this myself (good first issue)
+- [ ] Contribute requirements + use case, but need help implementing
+- [ ] Just requesting
+
+## Reference
+
+<!-- Existing connector to model after (e.g. PostgreSQL — `connectors/postgres.py`) -->

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release to PyPI
+name: Release
 
 on:
   push:
@@ -24,7 +24,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     permissions:
-      id-token: write  # trusted publishing
+      id-token: write  # trusted publishing to PyPI
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -33,3 +33,37 @@ jobs:
       - run: pip install build
       - run: python -m build
       - uses: pypa/gh-action-pypi-publish@release/v1
+
+  release-notes:
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # create releases
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history for changelog parsing
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#v}"
+
+          # Extract section for this version from CHANGELOG.md
+          NOTES=$(awk -v ver="## [${VERSION}]" '
+            $0 ~ ver,/^## \[/ {
+              if ($0 ~ ver) { print; next }
+              if ($0 ~ /^## \[/ && $0 !~ ver) exit
+              print
+            }
+          ' CHANGELOG.md)
+
+          if [ -z "$NOTES" ]; then
+            NOTES="See [CHANGELOG.md](CHANGELOG.md) for details."
+          fi
+
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes "$NOTES" \
+            --verify-tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,56 @@
+# Changelog
+
+All notable changes to Scherlok are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Snowflake connector (`pip install scherlok[snowflake]`)
+- Issue templates (bug, feature, new connector)
+- CHANGELOG.md
+- Automatic GitHub Release notes on tag push
+
+## [0.3.0] — 2026-04-22
+
+### Added
+- Generic webhook alerter — auto-detects Slack, Discord, Microsoft Teams, or generic JSON endpoints
+- `--webhook` / `-w` flag in the `watch` command
+
+### Removed
+- Removed legacy Slack-only path; replaced by the generic webhook
+
+## [0.2.2] — 2026-04-22
+
+### Fixed
+- Sync `__version__` between `pyproject.toml` and `src/scherlok/__init__.py`
+
+## [0.2.0] — 2026-04-22
+
+### Added
+- BigQuery connector (`pip install scherlok[bigquery]`)
+- Detective logo (AI-generated illustration)
+- Animated SVG demo in README
+- Examples folder with Docker + PostgreSQL quick start
+- 34 new tests across store, alerter, config, BigQuery (93 total)
+- PyPI release workflow with trusted publishing
+- Redesigned README
+
+## [0.1.0] — 2026-04-15
+
+### Added
+- Initial release
+- PostgreSQL connector
+- 6 anomaly detectors: volume, schema drift, freshness, nullability, distribution, cardinality
+- CLI with Typer (`connect`, `investigate`, `watch`, `report`, `status`, `history`, `version`)
+- Local SQLite storage + remote storage (S3, GCS, Azure Blob)
+- Slack webhook integration
+- 59 unit tests
+
+[Unreleased]: https://github.com/rbmuller/scherlok/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/rbmuller/scherlok/compare/v0.2.2...v0.3.0
+[0.2.2]: https://github.com/rbmuller/scherlok/compare/v0.2.0...v0.2.2
+[0.2.0]: https://github.com/rbmuller/scherlok/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/rbmuller/scherlok/releases/tag/v0.1.0


### PR DESCRIPTION
## Summary

- Issue templates: bug, feature request, new connector + disabled blank issues
- CHANGELOG.md (Keep a Changelog format) covering v0.1.0 → v0.3.0
- release.yml extracts notes from CHANGELOG.md and creates GitHub Release on tag push

## Test plan

- [ ] Open new issue from web UI → see templates
- [ ] Tag v0.4.0 after merge → GitHub Release auto-created with notes