### PR TITLE
feat: scherlok ci command + email alerter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Snowflake connector (`pip install scherlok[snowflake]`)
+- `scherlok ci` command — all-in-one CI/CD (connect + watch + exit code) in one line
+- Email alerter — `scherlok watch --email user@company.com` (configure via `SCHERLOK_SMTP_*` env vars)
+- Multi-recipient support: `--email` is repeatable
 - Issue templates (bug, feature, new connector)
 - CHANGELOG.md
 - Automatic GitHub Release notes on tag push

--- a/README.md
+++ b/README.md
@@ -117,18 +117,30 @@ Auto-detects Slack, Discord, and Teams from the URL and formats the payload acco
 
 ## CI/CD Integration
 
-Use Scherlok as a data quality gate:
+Use Scherlok as a data quality gate. The `ci` command does it in one line:
 
 ```yaml
 # GitHub Actions
 - name: Data quality check
   run: |
     pip install scherlok
-    scherlok connect ${{ secrets.DATABASE_URL }}
-    scherlok watch --exit-code --fail-on critical
+    scherlok config --store s3://my-bucket/scherlok/profiles.db
+    scherlok ci ${{ secrets.DATABASE_URL }} \
+      --webhook ${{ secrets.SLACK_WEBHOOK }} \
+      --fail-on critical
 ```
 
 If Scherlok detects a critical anomaly, the pipeline fails. Bad data never reaches production.
+
+## Email alerts
+
+```bash
+export SCHERLOK_SMTP_HOST=smtp.gmail.com
+export SCHERLOK_SMTP_USER=alerts@company.com
+export SCHERLOK_SMTP_PASSWORD=app-specific-password
+
+scherlok watch --email team@company.com --email cto@company.com
+```
 
 ## Connectors
 
@@ -187,7 +199,8 @@ scherlok config --store az://my-container/scherlok/profiles.db
 ```
 scherlok connect <url>          Connect to a database
 scherlok investigate            Profile all tables (learn patterns)
-scherlok watch [-w <url>]       Detect anomalies and alert
+scherlok watch [-w <url>] [-e <email>]  Detect anomalies and alert
+scherlok ci <url> [opts]        All-in-one CI/CD command (connect + watch + exit code)
 scherlok status                 Quick health dashboard
 scherlok report                 Detailed profile summary
 scherlok history [--days N]     Timeline of past anomalies

--- a/src/scherlok/alerter/email.py
+++ b/src/scherlok/alerter/email.py
@@ -1,0 +1,124 @@
+"""Email alerter — sends anomalies via SMTP.
+
+Configuration via environment variables:
+    SCHERLOK_SMTP_HOST       — required (e.g. smtp.gmail.com)
+    SCHERLOK_SMTP_PORT       — default 587
+    SCHERLOK_SMTP_USER       — required (sender login)
+    SCHERLOK_SMTP_PASSWORD   — required (or app password)
+    SCHERLOK_SMTP_FROM       — default = SMTP_USER
+    SCHERLOK_SMTP_USE_TLS    — default true
+"""
+
+import logging
+import os
+import smtplib
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+from scherlok.detector.severity import Severity
+
+logger = logging.getLogger(__name__)
+
+SEVERITY_COLOR = {
+    Severity.INFO: "#3b82f6",
+    Severity.WARNING: "#f59e0b",
+    Severity.CRITICAL: "#ef4444",
+}
+
+
+def _build_html(anomalies: list[dict]) -> str:
+    """Build HTML email body."""
+    cell = "padding:8px;border-bottom:1px solid #e5e7eb"
+    rows = []
+    for a in anomalies:
+        color = SEVERITY_COLOR.get(a["severity"], "#64748b")
+        rows.append(
+            f"<tr>"
+            f'<td style="{cell};color:{color};font-weight:bold">{a["severity"].value}</td>'
+            f'<td style="{cell};font-family:monospace">{a["table"]}</td>'
+            f'<td style="{cell}">{a["type"]}</td>'
+            f'<td style="{cell}">{a["message"]}</td>'
+            f"</tr>"
+        )
+
+    body_style = (
+        "font-family:-apple-system,BlinkMacSystemFont,sans-serif;"
+        "color:#111;max-width:720px;margin:0 auto;padding:24px"
+    )
+    return f"""\
+<!DOCTYPE html>
+<html>
+<body style="{body_style}">
+<h2 style="color:#0d9488">🔍 Scherlok Data Quality Alert</h2>
+<p>Detected <strong>{len(anomalies)}</strong> anomalies in your data.</p>
+<table style="width:100%;border-collapse:collapse;margin-top:16px">
+<thead>
+<tr style="background:#f3f4f6">
+<th style="padding:8px;text-align:left">Severity</th>
+<th style="padding:8px;text-align:left">Table</th>
+<th style="padding:8px;text-align:left">Type</th>
+<th style="padding:8px;text-align:left">Message</th>
+</tr>
+</thead>
+<tbody>
+{"".join(rows)}
+</tbody>
+</table>
+<p style="color:#64748b;font-size:12px;margin-top:24px">
+Sent by <a href="https://github.com/rbmuller/scherlok" style="color:#0d9488">Scherlok</a>
+</p>
+</body>
+</html>
+"""
+
+
+def _build_text(anomalies: list[dict]) -> str:
+    """Plain text fallback."""
+    lines = [f"Scherlok detected {len(anomalies)} anomalies:", ""]
+    for a in anomalies:
+        lines.append(f"[{a['severity'].value}] {a['table']} — {a['type']}: {a['message']}")
+    return "\n".join(lines)
+
+
+def send_email_alert(to_addresses: list[str], anomalies: list[dict]) -> bool:
+    """Send email alert with anomalies.
+
+    Returns True on success, False if SMTP misconfigured or send fails.
+    """
+    if not anomalies:
+        return True
+
+    host = os.environ.get("SCHERLOK_SMTP_HOST")
+    user = os.environ.get("SCHERLOK_SMTP_USER")
+    password = os.environ.get("SCHERLOK_SMTP_PASSWORD")
+    if not host or not user or not password:
+        logger.warning(
+            "SCHERLOK_SMTP_HOST/USER/PASSWORD env vars required for email alerts"
+        )
+        return False
+
+    port = int(os.environ.get("SCHERLOK_SMTP_PORT", "587"))
+    sender = os.environ.get("SCHERLOK_SMTP_FROM", user)
+    use_tls = os.environ.get("SCHERLOK_SMTP_USE_TLS", "true").lower() == "true"
+
+    msg = MIMEMultipart("alternative")
+    critical_count = sum(1 for a in anomalies if a["severity"] == Severity.CRITICAL)
+    prefix = "🔴 CRITICAL · " if critical_count else "⚠️  "
+    msg["Subject"] = f"{prefix}Scherlok: {len(anomalies)} anomalies detected"
+    msg["From"] = sender
+    msg["To"] = ", ".join(to_addresses)
+
+    msg.attach(MIMEText(_build_text(anomalies), "plain"))
+    msg.attach(MIMEText(_build_html(anomalies), "html"))
+
+    try:
+        with smtplib.SMTP(host, port, timeout=15) as smtp:
+            if use_tls:
+                smtp.starttls()
+            smtp.login(user, password)
+            smtp.send_message(msg)
+        logger.info("Email sent to %d recipients", len(to_addresses))
+        return True
+    except Exception as e:
+        logger.warning("Email delivery failed: %s", e)
+        return False

--- a/src/scherlok/cli.py
+++ b/src/scherlok/cli.py
@@ -7,6 +7,7 @@ from rich.table import Table
 
 from scherlok import __version__
 from scherlok.alerter.console import print_anomalies, print_profile_summary
+from scherlok.alerter.email import send_email_alert
 from scherlok.alerter.exitcode import exit_code_for
 from scherlok.alerter.webhook import send_webhook
 from scherlok.config import ScherlokConfig
@@ -140,19 +141,13 @@ def investigate() -> None:
         )
 
 
-@app.command()
-def watch(
-    webhook: str = typer.Option(
-        None, "--webhook", "-w",
-        help="Webhook URL to send alerts (auto-detects Slack, Discord, Teams).",
-    ),
-) -> None:
-    """Compare current state vs stored profile. Detect anomalies.
+def _run_watch(
+    webhook: str | None = None,
+    emails: list[str] | None = None,
+) -> list[dict]:
+    """Run the watch logic: profile + detect + alert. Returns all anomalies.
 
-    Example:
-        scherlok watch
-        scherlok watch --webhook https://hooks.slack.com/...
-        scherlok watch -w https://discord.com/api/webhooks/...
+    Reused by `watch` and `ci` commands.
     """
     connector = _get_connector_or_exit()
     cfg = ScherlokConfig.load()
@@ -166,7 +161,6 @@ def watch(
         console.print(f"Watching [bold]{len(tables)}[/bold] tables...")
 
         for table in tables:
-            # Volume detection
             current_vol = profile_volume(connector, table)
             stored_vol = store.get_latest_profile(table, "volume")
             if stored_vol:
@@ -174,7 +168,6 @@ def watch(
                     detect_volume_anomalies(table, current_vol, stored_vol)
                 )
 
-            # Schema drift detection
             current_sch = profile_schema(connector, table)
             stored_sch = store.get_latest_profile(table, "schema")
             if stored_sch:
@@ -182,7 +175,6 @@ def watch(
                     detect_schema_drift(table, current_sch, stored_sch)
                 )
 
-            # Freshness detection
             current_fresh = profile_freshness(connector, table)
             stored_fresh = store.get_latest_profile(table, "freshness")
             if stored_fresh:
@@ -190,7 +182,6 @@ def watch(
                     detect_freshness_anomalies(table, current_fresh, stored_fresh)
                 )
 
-            # Per-column detection: nullability, distribution shift, cardinality
             for col in (current_sch or {}).get("columns", []):
                 col_name = col["name"]
                 current_dist = profile_distribution(connector, table, col_name)
@@ -224,14 +215,93 @@ def watch(
             print_anomalies(all_anomalies)
             if webhook:
                 ok = send_webhook(webhook, all_anomalies)
-                if ok:
-                    console.print("[dim]Webhook sent.[/dim]")
-                else:
-                    console.print("[red]Webhook delivery failed.[/red]")
+                console.print(
+                    "[dim]Webhook sent.[/dim]" if ok else "[red]Webhook delivery failed.[/red]"
+                )
+            if emails:
+                ok = send_email_alert(emails, all_anomalies)
+                console.print(
+                    "[dim]Email sent.[/dim]" if ok else "[red]Email delivery failed.[/red]"
+                )
         else:
             console.print("[green]No anomalies detected.[/green]")
 
-    raise typer.Exit(code=exit_code_for(all_anomalies))
+    return all_anomalies
+
+
+@app.command()
+def watch(
+    webhook: str = typer.Option(
+        None, "--webhook", "-w",
+        help="Webhook URL to send alerts (auto-detects Slack, Discord, Teams).",
+    ),
+    email: list[str] = typer.Option(
+        None, "--email", "-e",
+        help="Email recipient(s) for alerts. Repeat to send to multiple.",
+    ),
+) -> None:
+    """Compare current state vs stored profile. Detect anomalies.
+
+    Example:
+        scherlok watch
+        scherlok watch --webhook https://hooks.slack.com/...
+        scherlok watch --email alice@company.com --email bob@company.com
+    """
+    anomalies = _run_watch(webhook=webhook, emails=email or None)
+    raise typer.Exit(code=exit_code_for(anomalies))
+
+
+@app.command()
+def ci(
+    connection_string: str = typer.Argument(
+        ..., help="Database connection string"
+    ),
+    webhook: str = typer.Option(
+        None, "--webhook", "-w", help="Webhook URL for alerts"
+    ),
+    email: list[str] = typer.Option(
+        None, "--email", "-e", help="Email recipient(s) for alerts"
+    ),
+    fail_on: str = typer.Option(
+        "critical", "--fail-on",
+        help="Severity that triggers exit code 1: 'critical' (default) or 'warning'",
+    ),
+) -> None:
+    """All-in-one CI/CD command: connect + investigate + watch + exit code.
+
+    Designed for use in pipelines. Profiles tables on first run (no anomalies),
+    then detects on subsequent runs against stored baseline (use remote storage).
+
+    Example:
+        # GitHub Actions
+        - run: |
+            pip install scherlok
+            scherlok config --store s3://my-bucket/scherlok/profiles.db
+            scherlok ci $DATABASE_URL --webhook $SLACK_URL --fail-on critical
+    """
+    # Save connection
+    cfg = ScherlokConfig.load()
+    cfg.connection_string = connection_string
+    cfg.save()
+
+    # Validate connection
+    connector = get_connector(connection_string)
+    if not connector.connect():
+        console.print("[red]Failed to connect.[/red]")
+        raise typer.Exit(code=1)
+
+    # Run watch (does profile + detect + alert in one)
+    anomalies = _run_watch(webhook=webhook, emails=email or None)
+
+    # Custom exit code based on --fail-on
+    fail_on_lower = fail_on.lower()
+    if fail_on_lower == "warning":
+        from scherlok.detector.severity import Severity
+        if any(a["severity"] in (Severity.WARNING, Severity.CRITICAL) for a in anomalies):
+            raise typer.Exit(code=1)
+    else:  # critical (default)
+        if exit_code_for(anomalies) == 1:
+            raise typer.Exit(code=1)
 
 
 @app.command()

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -1,0 +1,87 @@
+"""Tests for email alerter (SMTP)."""
+
+from unittest.mock import MagicMock, patch
+
+from scherlok.alerter.email import (
+    _build_html,
+    _build_text,
+    send_email_alert,
+)
+from scherlok.detector.severity import Severity
+
+
+def _anomalies():
+    return [
+        {
+            "table": "orders", "type": "volume_drop",
+            "severity": Severity.CRITICAL, "message": "Row count dropped 52%",
+        },
+        {
+            "table": "users", "type": "null_increase",
+            "severity": Severity.WARNING, "message": "NULL rate 2% → 18%",
+        },
+    ]
+
+
+class TestBuilders:
+    def test_html_contains_anomalies(self):
+        html = _build_html(_anomalies())
+        assert "Scherlok Data Quality Alert" in html
+        assert "orders" in html
+        assert "Row count dropped 52%" in html
+        assert "CRITICAL" in html
+
+    def test_text_contains_anomalies(self):
+        text = _build_text(_anomalies())
+        assert "2 anomalies" in text
+        assert "orders" in text
+        assert "users" in text
+
+
+class TestSendEmail:
+    def test_empty_anomalies_returns_true(self):
+        assert send_email_alert(["a@b.com"], []) is True
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_missing_smtp_config_returns_false(self):
+        assert send_email_alert(["a@b.com"], _anomalies()) is False
+
+    @patch.dict("os.environ", {
+        "SCHERLOK_SMTP_HOST": "smtp.example.com",
+        "SCHERLOK_SMTP_USER": "user@example.com",
+        "SCHERLOK_SMTP_PASSWORD": "pass",
+    })
+    @patch("scherlok.alerter.email.smtplib.SMTP")
+    def test_sends_successfully(self, mock_smtp_class):
+        mock_smtp = MagicMock()
+        mock_smtp_class.return_value.__enter__.return_value = mock_smtp
+
+        result = send_email_alert(["recipient@example.com"], _anomalies())
+        assert result is True
+        mock_smtp.starttls.assert_called_once()
+        mock_smtp.login.assert_called_once_with("user@example.com", "pass")
+        mock_smtp.send_message.assert_called_once()
+
+    @patch.dict("os.environ", {
+        "SCHERLOK_SMTP_HOST": "smtp.example.com",
+        "SCHERLOK_SMTP_USER": "user@example.com",
+        "SCHERLOK_SMTP_PASSWORD": "pass",
+    })
+    @patch("scherlok.alerter.email.smtplib.SMTP")
+    def test_returns_false_on_smtp_error(self, mock_smtp_class):
+        mock_smtp_class.side_effect = ConnectionRefusedError("nope")
+        assert send_email_alert(["a@b.com"], _anomalies()) is False
+
+    @patch.dict("os.environ", {
+        "SCHERLOK_SMTP_HOST": "smtp.example.com",
+        "SCHERLOK_SMTP_USER": "user@example.com",
+        "SCHERLOK_SMTP_PASSWORD": "pass",
+        "SCHERLOK_SMTP_USE_TLS": "false",
+    })
+    @patch("scherlok.alerter.email.smtplib.SMTP")
+    def test_skips_tls_when_disabled(self, mock_smtp_class):
+        mock_smtp = MagicMock()
+        mock_smtp_class.return_value.__enter__.return_value = mock_smtp
+
+        send_email_alert(["a@b.com"], _anomalies())
+        mock_smtp.starttls.assert_not_called()


### PR DESCRIPTION
## Summary

Two features in one PR:

### 1. \`scherlok ci\` command
All-in-one CI/CD command. Combines connect + watch + exit code in a single line.

\`\`\`yaml
- run: |
    pip install scherlok
    scherlok config --store s3://my-bucket/profiles.db
    scherlok ci \$DATABASE_URL --webhook \$SLACK_URL --fail-on critical
\`\`\`

### 2. Email alerter
Multipart HTML/text emails via SMTP. Multiple recipients supported.

\`\`\`bash
export SCHERLOK_SMTP_HOST=smtp.gmail.com
export SCHERLOK_SMTP_USER=alerts@company.com
export SCHERLOK_SMTP_PASSWORD=app-password
scherlok watch --email team@company.com --email cto@company.com
\`\`\`

### Refactor
Watch logic extracted to \`_run_watch()\` helper, reused by watch + ci.

## Test plan

- [x] 122/122 tests passing (7 new for email)
- [x] Lint clean
- [ ] Tag v0.5.0 after merge