### PR TITLE
feat: dbt v0 — investigate + watch dbt models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **dbt integration v0** — new `scherlok dbt` command. Reads `target/manifest.json`, discovers materialized models (`table`/`incremental`/`view`/`materialized_view`), auto-resolves the connection from `profiles.yml` (postgres / bigquery / snowflake), and runs investigate + watch per model with dbt-style ✓/✗ output.
+  - Optional dependency: `pip install scherlok[dbt]` (adds PyYAML)
+  - Flags: `--project-dir`, `--profiles-dir`, `--target`, `--connection-string`, `--select`, `--include-sources`, `--fail-on`, `--webhook`, `--email`
+  - Supports `{{ env_var('NAME', 'default') }}` rendering in `profiles.yml`
+  - Requires dbt 1.6+ (manifest schema v10+)
+
 ## [0.4.0] — 2026-04-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Use it as a CI gate after `dbt run`:
 
 **Supported adapters:** `postgres`, `bigquery`, `snowflake`. For others, pass `--connection-string` explicitly.
 
+📖 Full docs: [dbt integration guide →](src/scherlok/dbt/README.md)
+
 ## How It Works
 
 ### 1. `investigate` — Learn the patterns

--- a/README.md
+++ b/README.md
@@ -63,6 +63,38 @@ Three commands. Five minutes. Done.
 
 Every anomaly is auto-scored: **INFO**, **WARNING**, or **CRITICAL**. No thresholds to configure.
 
+## Works with dbt
+
+Already running dbt? Scherlok complements `dbt test` with **automatic** anomaly detection — no rules to write.
+
+```bash
+pip install scherlok[dbt]
+
+# After `dbt run`, point Scherlok at your project
+scherlok dbt --project-dir ./my_dbt_project
+```
+
+Scherlok reads `target/manifest.json`, discovers every materialized model (`table`, `incremental`, `view`), auto-resolves the connection from your `profiles.yml`, and profiles each model:
+
+```
+Investigating 4 dbt models in ./my_dbt_project (postgres)
+  ✓ stg_customers                  (12,345 rows)
+  ✓ stg_orders                     (98,765 rows)
+  ✗ fct_orders                     CRITICAL: Row count dropped 42% (98,765 → 57,283)
+  ✓ dim_customers_inc              (12,300 rows)
+
+Summary: 4 profiled, 1 anomalies (1 critical, 0 warning)
+```
+
+Use it as a CI gate after `dbt run`:
+
+```yaml
+- run: dbt run --target prod
+- run: scherlok dbt --project-dir . --target prod --fail-on critical
+```
+
+**Supported adapters:** `postgres`, `bigquery`, `snowflake`. For others, pass `--connection-string` explicitly.
+
 ## How It Works
 
 ### 1. `investigate` — Learn the patterns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,10 +35,14 @@ bigquery = [
 snowflake = [
     "snowflake-connector-python>=3.0.0",
 ]
+dbt = [
+    "pyyaml>=6.0",
+]
 dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
     "ruff>=0.1.0",
+    "pyyaml>=6.0",
 ]
 
 [project.scripts]

--- a/src/scherlok/cli.py
+++ b/src/scherlok/cli.py
@@ -141,90 +141,108 @@ def investigate() -> None:
         )
 
 
+def _watch_table(connector: object, store: ProfileStore, table: str) -> tuple[list[dict], dict]:
+    """Profile one table + detect anomalies against stored baseline. Saves new profiles.
+
+    Returns (anomalies, current_volume) — `current_volume` is handy for callers
+    that want to display row counts inline (e.g. dbt-style ✓/✗ output).
+    """
+    anomalies: list[dict] = []
+
+    current_vol = profile_volume(connector, table)
+    stored_vol = store.get_latest_profile(table, "volume")
+    if stored_vol:
+        anomalies.extend(detect_volume_anomalies(table, current_vol, stored_vol))
+
+    current_sch = profile_schema(connector, table)
+    stored_sch = store.get_latest_profile(table, "schema")
+    if stored_sch:
+        anomalies.extend(detect_schema_drift(table, current_sch, stored_sch))
+
+    current_fresh = profile_freshness(connector, table)
+    stored_fresh = store.get_latest_profile(table, "freshness")
+    if stored_fresh:
+        anomalies.extend(
+            detect_freshness_anomalies(table, current_fresh, stored_fresh)
+        )
+
+    for col in (current_sch or {}).get("columns", []):
+        col_name = col["name"]
+        current_dist = profile_distribution(connector, table, col_name)
+        stored_dist = store.get_latest_profile(table, f"distribution:{col_name}")
+        if stored_dist:
+            anomalies.extend(
+                detect_nullability_anomalies(table, col_name, current_dist, stored_dist)
+            )
+            anomalies.extend(
+                detect_distribution_shift(table, col_name, current_dist, stored_dist)
+            )
+            anomalies.extend(
+                detect_cardinality_anomalies(table, col_name, current_dist, stored_dist)
+            )
+        store.save_profile(table, f"distribution:{col_name}", current_dist)
+
+    store.save_profile(table, "volume", current_vol)
+    store.save_profile(table, "schema", current_sch)
+    store.save_profile(table, "freshness", current_fresh)
+
+    return anomalies, current_vol
+
+
+def _dispatch_alerts(
+    anomalies: list[dict],
+    store: ProfileStore,
+    webhook: str | None,
+    emails: list[str] | None,
+) -> None:
+    """Persist anomalies and fan out to webhook/email alerters."""
+    if not anomalies:
+        console.print("[green]No anomalies detected.[/green]")
+        return
+    store.save_anomalies(anomalies)
+    print_anomalies(anomalies)
+    if webhook:
+        ok = send_webhook(webhook, anomalies)
+        console.print(
+            "[dim]Webhook sent.[/dim]" if ok else "[red]Webhook delivery failed.[/red]"
+        )
+    if emails:
+        ok = send_email_alert(emails, anomalies)
+        console.print(
+            "[dim]Email sent.[/dim]" if ok else "[red]Email delivery failed.[/red]"
+        )
+
+
 def _run_watch(
     webhook: str | None = None,
     emails: list[str] | None = None,
+    tables: list[str] | None = None,
+    connector: object | None = None,
 ) -> list[dict]:
     """Run the watch logic: profile + detect + alert. Returns all anomalies.
 
-    Reused by `watch` and `ci` commands.
+    Reused by `watch`, `ci`, and `dbt` commands. When `tables` is None, all
+    tables visible to the connector are used. When `connector` is None, one
+    is loaded from the saved config.
     """
-    connector = _get_connector_or_exit()
+    if connector is None:
+        connector = _get_connector_or_exit()
     cfg = ScherlokConfig.load()
 
     from scherlok.config import PROFILES_DB
     with sync_context(cfg.get_store(), PROFILES_DB):
         store = ProfileStore()
-        tables = connector.list_tables()
+        if tables is None:
+            tables = connector.list_tables()
         all_anomalies: list[dict] = []
 
         console.print(f"Watching [bold]{len(tables)}[/bold] tables...")
 
         for table in tables:
-            current_vol = profile_volume(connector, table)
-            stored_vol = store.get_latest_profile(table, "volume")
-            if stored_vol:
-                all_anomalies.extend(
-                    detect_volume_anomalies(table, current_vol, stored_vol)
-                )
+            anomalies, _ = _watch_table(connector, store, table)
+            all_anomalies.extend(anomalies)
 
-            current_sch = profile_schema(connector, table)
-            stored_sch = store.get_latest_profile(table, "schema")
-            if stored_sch:
-                all_anomalies.extend(
-                    detect_schema_drift(table, current_sch, stored_sch)
-                )
-
-            current_fresh = profile_freshness(connector, table)
-            stored_fresh = store.get_latest_profile(table, "freshness")
-            if stored_fresh:
-                all_anomalies.extend(
-                    detect_freshness_anomalies(table, current_fresh, stored_fresh)
-                )
-
-            for col in (current_sch or {}).get("columns", []):
-                col_name = col["name"]
-                current_dist = profile_distribution(connector, table, col_name)
-                stored_dist = store.get_latest_profile(
-                    table, f"distribution:{col_name}"
-                )
-                if stored_dist:
-                    all_anomalies.extend(
-                        detect_nullability_anomalies(
-                            table, col_name, current_dist, stored_dist
-                        )
-                    )
-                    all_anomalies.extend(
-                        detect_distribution_shift(
-                            table, col_name, current_dist, stored_dist
-                        )
-                    )
-                    all_anomalies.extend(
-                        detect_cardinality_anomalies(
-                            table, col_name, current_dist, stored_dist
-                        )
-                    )
-                store.save_profile(table, f"distribution:{col_name}", current_dist)
-
-            store.save_profile(table, "volume", current_vol)
-            store.save_profile(table, "schema", current_sch)
-            store.save_profile(table, "freshness", current_fresh)
-
-        if all_anomalies:
-            store.save_anomalies(all_anomalies)
-            print_anomalies(all_anomalies)
-            if webhook:
-                ok = send_webhook(webhook, all_anomalies)
-                console.print(
-                    "[dim]Webhook sent.[/dim]" if ok else "[red]Webhook delivery failed.[/red]"
-                )
-            if emails:
-                ok = send_email_alert(emails, all_anomalies)
-                console.print(
-                    "[dim]Email sent.[/dim]" if ok else "[red]Email delivery failed.[/red]"
-                )
-        else:
-            console.print("[green]No anomalies detected.[/green]")
+        _dispatch_alerts(all_anomalies, store, webhook, emails)
 
     return all_anomalies
 
@@ -302,6 +320,187 @@ def ci(
     else:  # critical (default)
         if exit_code_for(anomalies) == 1:
             raise typer.Exit(code=1)
+
+
+@app.command()
+def dbt(
+    project_dir: str = typer.Option(
+        ".", "--project-dir", help="Path to dbt project root (containing dbt_project.yml)"
+    ),
+    profiles_dir: str = typer.Option(
+        None, "--profiles-dir", help="Path to dir containing profiles.yml (default: ~/.dbt)"
+    ),
+    target: str = typer.Option(
+        None, "--target", help="dbt target to use (default: profile's `target:` key)"
+    ),
+    connection_string: str = typer.Option(
+        None, "--connection-string",
+        help="Override profiles.yml resolution and use this connection string directly",
+    ),
+    select: list[str] = typer.Option(
+        None, "--select", "-s",
+        help="Only profile these models (by name). Repeat to select multiple.",
+    ),
+    include_sources: bool = typer.Option(
+        False, "--include-sources", help="Also profile dbt sources, not only models"
+    ),
+    webhook: str = typer.Option(
+        None, "--webhook", "-w", help="Webhook URL for alerts"
+    ),
+    email: list[str] = typer.Option(
+        None, "--email", "-e", help="Email recipient(s) for alerts"
+    ),
+    fail_on: str = typer.Option(
+        "critical", "--fail-on",
+        help="Severity that triggers exit code 1: 'critical' (default) or 'warning'",
+    ),
+) -> None:
+    """Profile and watch dbt models. Reads target/manifest.json.
+
+    Run this after `dbt run` to detect anomalies in materialized models.
+    First run profiles a baseline; subsequent runs detect drift.
+
+    Example:
+        scherlok dbt --project-dir ./my_dbt_project
+        scherlok dbt --project-dir . --select stg_orders --select fct_orders
+        scherlok dbt --project-dir . --connection-string postgresql://...
+    """
+    from scherlok.dbt import (
+        DbtNode,
+        ProfileResolutionError,
+        discover_models,
+        discover_sources,
+        load_manifest,
+        resolve_connection_string,
+    )
+
+    # 1. Load manifest
+    try:
+        manifest = load_manifest(project_dir)
+    except (FileNotFoundError, ValueError) as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1) from exc
+
+    adapter = manifest.get("metadata", {}).get("adapter_type", "?")
+    nodes: list[DbtNode] = discover_models(manifest)
+    if include_sources:
+        nodes.extend(discover_sources(manifest))
+
+    if select:
+        wanted = set(select)
+        nodes = [n for n in nodes if n.name in wanted or n.identifier in wanted]
+        if not nodes:
+            console.print(f"[red]No models matched --select {list(wanted)}.[/red]")
+            raise typer.Exit(code=1)
+
+    if not nodes:
+        console.print("[yellow]No materialized models found in manifest.[/yellow]")
+        raise typer.Exit(code=0)
+
+    # 2. Resolve connection string
+    if connection_string:
+        conn_str = connection_string
+    else:
+        try:
+            conn_str = resolve_connection_string(
+                project_dir, profiles_dir=profiles_dir, target=target
+            )
+        except ProfileResolutionError as exc:
+            console.print(f"[red]{exc}[/red]")
+            raise typer.Exit(code=1) from exc
+
+    cfg = ScherlokConfig.load()
+    cfg.connection_string = conn_str
+    cfg.save()
+
+    connector = get_connector(conn_str)
+    if not connector.connect():
+        console.print("[red]Failed to connect using the resolved connection.[/red]")
+        raise typer.Exit(code=1)
+
+    # 3. Match models to physical tables visible to the connector
+    visible = set(connector.list_tables())
+    matched: list[tuple[DbtNode, str]] = []
+    missing: list[DbtNode] = []
+    for node in nodes:
+        physical = _resolve_physical_table(node, visible)
+        if physical is None:
+            missing.append(node)
+        else:
+            matched.append((node, physical))
+
+    console.print(
+        f"Investigating [bold]{len(matched)}[/bold] dbt {'nodes' if include_sources else 'models'} "
+        f"in [cyan]{project_dir}[/cyan] ([dim]{adapter}[/dim])"
+    )
+    if missing:
+        console.print(
+            f"[yellow]Skipped {len(missing)} not found in {adapter}: "
+            f"{', '.join(n.name for n in missing[:5])}"
+            f"{' …' if len(missing) > 5 else ''}[/yellow]"
+        )
+
+    # 4. Per-model investigate + watch
+    from scherlok.config import PROFILES_DB
+    all_anomalies: list[dict] = []
+    with sync_context(cfg.get_store(), PROFILES_DB):
+        store = ProfileStore()
+        for node, physical in matched:
+            table_anomalies, current_vol = _watch_table(connector, store, physical)
+            all_anomalies.extend(table_anomalies)
+            _print_dbt_model_result(node, physical, current_vol, table_anomalies)
+        _dispatch_alerts(all_anomalies, store, webhook, email or None)
+
+    # 5. Summary + exit code
+    crit = sum(1 for a in all_anomalies if str(a.get("severity")).endswith("CRITICAL"))
+    warn = sum(1 for a in all_anomalies if str(a.get("severity")).endswith("WARNING"))
+    console.print(
+        f"\n[bold]Summary:[/bold] {len(matched)} profiled, "
+        f"{len(all_anomalies)} anomalies "
+        f"([red]{crit} critical[/red], [yellow]{warn} warning[/yellow])"
+    )
+
+    fail_on_lower = fail_on.lower()
+    if fail_on_lower == "warning":
+        from scherlok.detector.severity import Severity
+        if any(
+            a["severity"] in (Severity.WARNING, Severity.CRITICAL) for a in all_anomalies
+        ):
+            raise typer.Exit(code=1)
+    else:
+        if exit_code_for(all_anomalies) == 1:
+            raise typer.Exit(code=1)
+
+
+def _resolve_physical_table(node: object, visible: set[str]) -> str | None:
+    """Match a dbt node to a physical table name visible to the connector.
+
+    Tries identifier first, then name; for Snowflake also tries uppercase variants.
+    """
+    candidates = [node.identifier, node.name]  # type: ignore[attr-defined]
+    if node.adapter == "snowflake":  # type: ignore[attr-defined]
+        candidates.extend([c.upper() for c in candidates if c])
+    for cand in candidates:
+        if cand and cand in visible:
+            return cand
+    return None
+
+
+def _print_dbt_model_result(
+    node: object, physical: str, current_vol: dict, anomalies: list[dict]
+) -> None:
+    """Print one ✓/✗ line for a dbt model with row count or anomaly summary."""
+    name = node.name  # type: ignore[attr-defined]
+    if not anomalies:
+        rows = current_vol.get("row_count", "?")
+        console.print(f"  [green]✓[/green] {name:<30} ({rows:,} rows)")
+        return
+    # Show the worst anomaly summary on the line
+    severities = [str(a.get("severity")) for a in anomalies]
+    worst = "CRITICAL" if any("CRITICAL" in s for s in severities) else "WARNING"
+    color = "red" if worst == "CRITICAL" else "yellow"
+    msg = anomalies[0].get("message", "anomaly detected")
+    console.print(f"  [{color}]✗[/{color}] {name:<30} {worst}: {msg}")
 
 
 @app.command()

--- a/src/scherlok/dbt/README.md
+++ b/src/scherlok/dbt/README.md
@@ -1,0 +1,91 @@
+# dbt Integration
+
+Scherlok reads dbt's `target/manifest.json` to discover models and run anomaly detection on each one — no rules to write, no YAML to maintain. It complements `dbt test`: where dbt tests check assertions you wrote, Scherlok detects drift you didn't think to check.
+
+## Install
+
+```bash
+pip install scherlok[dbt]
+```
+
+The `[dbt]` extra adds PyYAML for parsing `profiles.yml`. The base scherlok install (`pip install scherlok`) is enough if you always pass `--connection-string` explicitly.
+
+## Quick start
+
+```bash
+# After `dbt run` in your dbt project:
+scherlok dbt --project-dir ./my_dbt_project
+```
+
+Scherlok will:
+1. Read `target/manifest.json` and discover every materialized model
+2. Resolve the connection from `profiles.yml` (or `--connection-string`)
+3. Profile every model and detect anomalies against the stored baseline
+4. Print one ✓/✗ line per model + a summary
+
+First run = baseline. Subsequent runs detect drift.
+
+## How it discovers what to profile
+
+- **Materialized models only.** Models with `materialized: ephemeral` are skipped (they don't exist in the warehouse).
+- **Tests / seeds / snapshots are skipped** in v0 — only `resource_type: model` (and optionally `source` with `--include-sources`) are profiled.
+- **Filtering:** `--select fct_orders --select stg_orders` profiles only the listed models.
+
+## Supported adapters
+
+| Adapter | Status |
+|---------|--------|
+| `postgres` | ✅ |
+| `bigquery` | ✅ |
+| `snowflake` | ✅ |
+| Others (Redshift, Databricks, DuckDB, …) | ❌ — use `--connection-string` |
+
+For unsupported adapters, point Scherlok at the warehouse directly:
+
+```bash
+scherlok dbt --project-dir . --connection-string "postgresql://user:pw@host/db"
+```
+
+## Connection resolution
+
+When `--connection-string` is **not** set, Scherlok resolves the connection from `profiles.yml`:
+
+1. Reads `dbt_project.yml` to find the `profile:` name.
+2. Looks the profile up in `profiles.yml` (search order: `--profiles-dir` → `$DBT_PROFILES_DIR` → `~/.dbt`).
+3. Selects the target via `--target` or the profile's default `target:` key.
+4. Renders `{{ env_var('NAME') }}` and `{{ env_var('NAME', 'default') }}` from the environment.
+5. Builds a Scherlok connection string for the matched adapter.
+
+> Only `env_var` is rendered. Anything else (full Jinja, secrets resolvers, etc.) raises and asks you to pass `--connection-string`.
+
+## CI/CD usage
+
+Add Scherlok as a gate after `dbt run`:
+
+```yaml
+# .github/workflows/dbt.yml
+- run: dbt run --target prod
+- run: |
+    pip install scherlok[dbt]
+    scherlok config --store s3://my-bucket/scherlok/profiles.db
+    scherlok dbt --project-dir . --target prod --fail-on critical \
+                 --webhook ${{ secrets.SLACK_WEBHOOK }}
+```
+
+`--fail-on critical` exits with code 1 when any CRITICAL anomaly is detected; `--fail-on warning` is stricter and fails on WARNING+ as well.
+
+## What's coming next (Month 5)
+
+- GitHub Action wrapper (`uses: rbmuller/scherlok-action@v1`)
+- `scherlok dbt run-and-watch` — runs `dbt run` and `scherlok dbt` in sequence
+- ASCII lineage tree from `manifest.parent_map` / `child_map`
+- JSON output for CI (`--output json`)
+
+## Limitations of v0
+
+- No support for ephemeral models (they're not materialized — nothing to profile).
+- No support for adapter-specific Jinja in `profiles.yml` beyond `env_var`.
+- Lineage is **not yet** read from the manifest — anomalies are reported per-model with no downstream impact.
+- Snapshots are not profiled in v0.
+
+If you hit one of these, please open an issue.

--- a/src/scherlok/dbt/__init__.py
+++ b/src/scherlok/dbt/__init__.py
@@ -1,0 +1,17 @@
+"""dbt integration: parse manifest.json and run investigate/watch per model.
+
+Reuses existing connectors (Postgres/BigQuery/Snowflake). No runtime dependency
+on dbt-core — only reads JSON/YAML files produced by dbt.
+"""
+
+from scherlok.dbt.manifest import DbtNode, discover_models, discover_sources, load_manifest
+from scherlok.dbt.profiles import ProfileResolutionError, resolve_connection_string
+
+__all__ = [
+    "DbtNode",
+    "ProfileResolutionError",
+    "discover_models",
+    "discover_sources",
+    "load_manifest",
+    "resolve_connection_string",
+]

--- a/src/scherlok/dbt/manifest.py
+++ b/src/scherlok/dbt/manifest.py
@@ -1,0 +1,139 @@
+"""Parse dbt's target/manifest.json to discover models and sources."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+MIN_MANIFEST_VERSION = 10  # dbt 1.6+
+MATERIALIZED_PHYSICAL = {"table", "incremental", "view", "materialized_view"}
+SUPPORTED_ADAPTERS = {"postgres", "bigquery", "snowflake"}
+
+
+@dataclass(frozen=True)
+class DbtNode:
+    """A dbt model or source resolved to a physical relation."""
+
+    unique_id: str
+    name: str
+    resource_type: str  # "model" or "source"
+    materialized: str  # for sources: "source"
+    database: str
+    schema: str
+    identifier: str  # alias for models, identifier for sources
+    relation_name: str | None  # quoted FQN as dbt produced it (may be None)
+    adapter: str  # postgres / bigquery / snowflake
+
+
+def load_manifest(project_dir: str | Path) -> dict:
+    """Load and validate target/manifest.json from a dbt project directory.
+
+    Args:
+        project_dir: Path to the dbt project root (must contain target/manifest.json).
+
+    Raises:
+        FileNotFoundError: When manifest.json is missing.
+        ValueError: When manifest_version is too old or adapter is unsupported.
+    """
+    project_path = Path(project_dir)
+    manifest_path = project_path / "target" / "manifest.json"
+    if not manifest_path.is_file():
+        raise FileNotFoundError(
+            f"manifest.json not found at {manifest_path}. "
+            f"Run `dbt compile` or `dbt run` first."
+        )
+
+    with manifest_path.open("r", encoding="utf-8") as f:
+        manifest = json.load(f)
+
+    version = _parse_manifest_version(manifest)
+    if version < MIN_MANIFEST_VERSION:
+        raise ValueError(
+            f"Unsupported manifest_version v{version}. "
+            f"Scherlok requires dbt 1.6+ (manifest v{MIN_MANIFEST_VERSION}+). "
+            f"Upgrade dbt and re-run `dbt compile`."
+        )
+
+    adapter = manifest.get("metadata", {}).get("adapter_type")
+    if adapter and adapter not in SUPPORTED_ADAPTERS:
+        raise ValueError(
+            f"Unsupported dbt adapter '{adapter}'. "
+            f"Supported: {sorted(SUPPORTED_ADAPTERS)}. "
+            f"Use --connection-string to bypass profiles.yml resolution."
+        )
+
+    return manifest
+
+
+def discover_models(manifest: dict) -> list[DbtNode]:
+    """Return all materialized models (table/incremental/view) from the manifest."""
+    adapter = manifest.get("metadata", {}).get("adapter_type", "")
+    nodes = manifest.get("nodes", {})
+    models: list[DbtNode] = []
+
+    for unique_id, node in nodes.items():
+        if node.get("resource_type") != "model":
+            continue
+        materialized = node.get("config", {}).get("materialized", "")
+        if materialized not in MATERIALIZED_PHYSICAL:
+            continue
+
+        identifier = node.get("alias") or node.get("name", "")
+        models.append(
+            DbtNode(
+                unique_id=unique_id,
+                name=node.get("name", ""),
+                resource_type="model",
+                materialized=materialized,
+                database=node.get("database", "") or "",
+                schema=node.get("schema", "") or "",
+                identifier=identifier,
+                relation_name=node.get("relation_name"),
+                adapter=adapter,
+            )
+        )
+
+    return models
+
+
+def discover_sources(manifest: dict) -> list[DbtNode]:
+    """Return all sources from the manifest."""
+    adapter = manifest.get("metadata", {}).get("adapter_type", "")
+    sources_dict = manifest.get("sources", {})
+    sources: list[DbtNode] = []
+
+    for unique_id, src in sources_dict.items():
+        identifier = src.get("identifier") or src.get("name", "")
+        sources.append(
+            DbtNode(
+                unique_id=unique_id,
+                name=src.get("name", ""),
+                resource_type="source",
+                materialized="source",
+                database=src.get("database", "") or "",
+                schema=src.get("schema", "") or "",
+                identifier=identifier,
+                relation_name=src.get("relation_name"),
+                adapter=adapter,
+            )
+        )
+
+    return sources
+
+
+def _parse_manifest_version(manifest: dict) -> int:
+    """Extract integer version from metadata.dbt_schema_version URL.
+
+    Examples:
+        "https://schemas.getdbt.com/dbt/manifest/v10.json" -> 10
+        "https://schemas.getdbt.com/dbt/manifest/v12.json" -> 12
+    """
+    raw = manifest.get("metadata", {}).get("dbt_schema_version", "")
+    # Format: .../manifest/v<N>.json
+    try:
+        tail = raw.rsplit("/", 1)[-1]  # "v10.json"
+        num = tail.lstrip("v").split(".", 1)[0]  # "10"
+        return int(num)
+    except (ValueError, IndexError):
+        return 0

--- a/src/scherlok/dbt/profiles.py
+++ b/src/scherlok/dbt/profiles.py
@@ -1,0 +1,178 @@
+"""Resolve a Scherlok connection string from a dbt project's profiles.yml.
+
+Supports the three adapters Scherlok already speaks: postgres, bigquery, snowflake.
+Renders only `{{ env_var('FOO') }}` / `{{ env_var('FOO', 'default') }}` — anything
+else (full Jinja, secrets:// resolvers, etc.) raises and asks the user to pass
+--connection-string explicitly.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+ENV_VAR_PATTERN = re.compile(
+    r"""\{\{\s*env_var\(\s*['"]([^'"]+)['"](?:\s*,\s*['"]([^'"]*)['"])?\s*\)\s*\}\}"""
+)
+
+
+class ProfileResolutionError(ValueError):
+    """Raised when profiles.yml cannot be resolved into a connection string."""
+
+
+def resolve_connection_string(
+    project_dir: str | Path,
+    profiles_dir: str | Path | None = None,
+    target: str | None = None,
+) -> str:
+    """Resolve the connection string for a dbt project.
+
+    Reads dbt_project.yml to find the profile name, then looks it up in
+    profiles.yml under the chosen target.
+
+    Args:
+        project_dir: Path to the dbt project root (must contain dbt_project.yml).
+        profiles_dir: Where profiles.yml lives. Defaults to ~/.dbt.
+        target: Override the default target from profiles.yml.
+
+    Raises:
+        ProfileResolutionError: When required files/keys are missing or the
+            adapter is unsupported.
+    """
+    try:
+        import yaml  # type: ignore[import-untyped]
+    except ImportError as exc:
+        raise ProfileResolutionError(
+            "PyYAML not installed. Install with `pip install scherlok[dbt]` "
+            "or pass --connection-string explicitly."
+        ) from exc
+
+    project_path = Path(project_dir)
+    project_yml_path = project_path / "dbt_project.yml"
+    if not project_yml_path.is_file():
+        raise ProfileResolutionError(
+            f"dbt_project.yml not found at {project_yml_path}."
+        )
+
+    with project_yml_path.open("r", encoding="utf-8") as f:
+        project_yml = yaml.safe_load(f) or {}
+
+    profile_name = project_yml.get("profile")
+    if not profile_name:
+        raise ProfileResolutionError(
+            f"`profile:` key missing from {project_yml_path}."
+        )
+
+    profiles_path = _resolve_profiles_path(profiles_dir)
+    if not profiles_path.is_file():
+        raise ProfileResolutionError(
+            f"profiles.yml not found at {profiles_path}. "
+            f"Set DBT_PROFILES_DIR or pass --profiles-dir."
+        )
+
+    with profiles_path.open("r", encoding="utf-8") as f:
+        profiles_yml = yaml.safe_load(f) or {}
+
+    profile = profiles_yml.get(profile_name)
+    if not profile:
+        raise ProfileResolutionError(
+            f"Profile '{profile_name}' not found in {profiles_path}."
+        )
+
+    chosen_target = target or profile.get("target")
+    if not chosen_target:
+        raise ProfileResolutionError(
+            f"No target specified and profile '{profile_name}' has no default target."
+        )
+
+    outputs = profile.get("outputs", {})
+    output = outputs.get(chosen_target)
+    if not output:
+        raise ProfileResolutionError(
+            f"Target '{chosen_target}' not found under profile '{profile_name}'."
+        )
+
+    rendered = _render_env_vars(output)
+    return _output_to_connection_string(rendered)
+
+
+def _resolve_profiles_path(profiles_dir: str | Path | None) -> Path:
+    """Return the absolute path to profiles.yml."""
+    if profiles_dir:
+        return Path(profiles_dir) / "profiles.yml"
+    env_dir = os.environ.get("DBT_PROFILES_DIR")
+    if env_dir:
+        return Path(env_dir) / "profiles.yml"
+    return Path.home() / ".dbt" / "profiles.yml"
+
+
+def _render_env_vars(value: Any) -> Any:
+    """Recursively render `{{ env_var('NAME', 'default') }}` in strings."""
+    if isinstance(value, str):
+        return ENV_VAR_PATTERN.sub(_replace_env_var, value)
+    if isinstance(value, dict):
+        return {k: _render_env_vars(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_render_env_vars(v) for v in value]
+    return value
+
+
+def _replace_env_var(match: re.Match) -> str:
+    name = match.group(1)
+    default = match.group(2) or ""
+    return os.environ.get(name, default)
+
+
+def _output_to_connection_string(output: dict) -> str:
+    """Map a rendered dbt output block to a Scherlok connection string."""
+    adapter_type = output.get("type", "")
+
+    if adapter_type == "postgres":
+        return _postgres_connection_string(output)
+    if adapter_type == "bigquery":
+        return _bigquery_connection_string(output)
+    if adapter_type == "snowflake":
+        return _snowflake_connection_string(output)
+
+    raise ProfileResolutionError(
+        f"Unsupported dbt adapter '{adapter_type}'. "
+        f"Supported: postgres, bigquery, snowflake. "
+        f"Use --connection-string to bypass profiles.yml."
+    )
+
+
+def _postgres_connection_string(output: dict) -> str:
+    user = output.get("user", "")
+    password = output.get("password", "")
+    host = output.get("host", "localhost")
+    port = output.get("port", 5432)
+    dbname = output.get("dbname") or output.get("database", "")
+    if not user or not dbname:
+        raise ProfileResolutionError(
+            "Postgres profile missing required fields: user, dbname."
+        )
+    auth = f"{user}:{password}@" if password else f"{user}@"
+    return f"postgresql://{auth}{host}:{port}/{dbname}"
+
+
+def _bigquery_connection_string(output: dict) -> str:
+    project = output.get("project") or output.get("database", "")
+    dataset = output.get("dataset") or output.get("schema", "")
+    if not project or not dataset:
+        raise ProfileResolutionError(
+            "BigQuery profile missing required fields: project, dataset."
+        )
+    return f"bigquery://{project}/{dataset}"
+
+
+def _snowflake_connection_string(output: dict) -> str:
+    account = output.get("account", "")
+    database = output.get("database", "")
+    schema = output.get("schema", "")
+    if not account or not database or not schema:
+        raise ProfileResolutionError(
+            "Snowflake profile missing required fields: account, database, schema."
+        )
+    return f"snowflake://{account}/{database}/{schema}"

--- a/tests/fixtures/dbt/jaffle_shop_old/target/manifest.json
+++ b/tests/fixtures/dbt/jaffle_shop_old/target/manifest.json
@@ -1,0 +1,10 @@
+{
+  "metadata": {
+    "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v8.json",
+    "dbt_version": "1.4.0",
+    "adapter_type": "postgres",
+    "project_name": "jaffle_shop"
+  },
+  "nodes": {},
+  "sources": {}
+}

--- a/tests/fixtures/dbt/jaffle_shop_postgres/dbt_project.yml
+++ b/tests/fixtures/dbt/jaffle_shop_postgres/dbt_project.yml
@@ -1,0 +1,4 @@
+name: jaffle_shop
+version: '1.0.0'
+profile: jaffle_shop
+config-version: 2

--- a/tests/fixtures/dbt/jaffle_shop_postgres/target/manifest.json
+++ b/tests/fixtures/dbt/jaffle_shop_postgres/target/manifest.json
@@ -1,0 +1,81 @@
+{
+  "metadata": {
+    "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
+    "dbt_version": "1.8.0",
+    "generated_at": "2026-04-30T12:00:00.000000Z",
+    "adapter_type": "postgres",
+    "project_name": "jaffle_shop"
+  },
+  "nodes": {
+    "model.jaffle_shop.stg_customers": {
+      "resource_type": "model",
+      "name": "stg_customers",
+      "alias": "stg_customers",
+      "database": "jaffle_db",
+      "schema": "public",
+      "fqn": ["jaffle_shop", "staging", "stg_customers"],
+      "relation_name": "\"jaffle_db\".\"public\".\"stg_customers\"",
+      "config": {"materialized": "view"}
+    },
+    "model.jaffle_shop.stg_orders": {
+      "resource_type": "model",
+      "name": "stg_orders",
+      "alias": "stg_orders",
+      "database": "jaffle_db",
+      "schema": "public",
+      "fqn": ["jaffle_shop", "staging", "stg_orders"],
+      "relation_name": "\"jaffle_db\".\"public\".\"stg_orders\"",
+      "config": {"materialized": "view"}
+    },
+    "model.jaffle_shop.fct_orders": {
+      "resource_type": "model",
+      "name": "fct_orders",
+      "alias": "fct_orders",
+      "database": "jaffle_db",
+      "schema": "public",
+      "fqn": ["jaffle_shop", "marts", "fct_orders"],
+      "relation_name": "\"jaffle_db\".\"public\".\"fct_orders\"",
+      "config": {"materialized": "table"}
+    },
+    "model.jaffle_shop.int_orders_pivoted": {
+      "resource_type": "model",
+      "name": "int_orders_pivoted",
+      "alias": "int_orders_pivoted",
+      "database": "jaffle_db",
+      "schema": "public",
+      "fqn": ["jaffle_shop", "intermediate", "int_orders_pivoted"],
+      "relation_name": null,
+      "config": {"materialized": "ephemeral"}
+    },
+    "model.jaffle_shop.dim_customers_inc": {
+      "resource_type": "model",
+      "name": "dim_customers_inc",
+      "alias": "dim_customers_inc",
+      "database": "jaffle_db",
+      "schema": "public",
+      "fqn": ["jaffle_shop", "marts", "dim_customers_inc"],
+      "relation_name": "\"jaffle_db\".\"public\".\"dim_customers_inc\"",
+      "config": {"materialized": "incremental"}
+    },
+    "test.jaffle_shop.unique_stg_customers_id.abc123": {
+      "resource_type": "test",
+      "name": "unique_stg_customers_id",
+      "config": {}
+    },
+    "seed.jaffle_shop.raw_customers": {
+      "resource_type": "seed",
+      "name": "raw_customers",
+      "config": {"materialized": "seed"}
+    }
+  },
+  "sources": {
+    "source.jaffle_shop.raw.payments": {
+      "resource_type": "source",
+      "name": "payments",
+      "identifier": "raw_payments",
+      "database": "jaffle_db",
+      "schema": "raw",
+      "relation_name": "\"jaffle_db\".\"raw\".\"raw_payments\""
+    }
+  }
+}

--- a/tests/fixtures/dbt/jaffle_shop_snowflake/dbt_project.yml
+++ b/tests/fixtures/dbt/jaffle_shop_snowflake/dbt_project.yml
@@ -1,0 +1,4 @@
+name: jaffle_shop
+version: '1.0.0'
+profile: jaffle_shop
+config-version: 2

--- a/tests/fixtures/dbt/jaffle_shop_snowflake/target/manifest.json
+++ b/tests/fixtures/dbt/jaffle_shop_snowflake/target/manifest.json
@@ -1,0 +1,21 @@
+{
+  "metadata": {
+    "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
+    "dbt_version": "1.8.0",
+    "adapter_type": "snowflake",
+    "project_name": "jaffle_shop"
+  },
+  "nodes": {
+    "model.jaffle_shop.STG_ORDERS": {
+      "resource_type": "model",
+      "name": "stg_orders",
+      "alias": "STG_ORDERS",
+      "database": "ANALYTICS",
+      "schema": "PUBLIC",
+      "fqn": ["jaffle_shop", "staging", "stg_orders"],
+      "relation_name": "ANALYTICS.PUBLIC.STG_ORDERS",
+      "config": {"materialized": "table"}
+    }
+  },
+  "sources": {}
+}

--- a/tests/fixtures/dbt/profiles_bigquery/profiles.yml
+++ b/tests/fixtures/dbt/profiles_bigquery/profiles.yml
@@ -1,0 +1,10 @@
+jaffle_shop:
+  target: dev
+  outputs:
+    dev:
+      type: bigquery
+      method: oauth
+      project: my-gcp-project
+      dataset: jaffle_shop
+      threads: 4
+      location: US

--- a/tests/fixtures/dbt/profiles_postgres/profiles.yml
+++ b/tests/fixtures/dbt/profiles_postgres/profiles.yml
@@ -1,0 +1,19 @@
+jaffle_shop:
+  target: dev
+  outputs:
+    dev:
+      type: postgres
+      host: localhost
+      port: 5432
+      user: "{{ env_var('PG_USER', 'jaffle') }}"
+      password: "{{ env_var('PG_PASSWORD', 'secret') }}"
+      dbname: jaffle_db
+      schema: public
+    prod:
+      type: postgres
+      host: prod-host
+      port: 5432
+      user: prod_user
+      password: prod_pw
+      dbname: jaffle_prod
+      schema: public

--- a/tests/fixtures/dbt/profiles_snowflake/profiles.yml
+++ b/tests/fixtures/dbt/profiles_snowflake/profiles.yml
@@ -1,0 +1,12 @@
+jaffle_shop:
+  target: dev
+  outputs:
+    dev:
+      type: snowflake
+      account: my-account.us-east-1
+      user: "{{ env_var('SF_USER') }}"
+      password: "{{ env_var('SF_PASSWORD') }}"
+      database: ANALYTICS
+      schema: PUBLIC
+      warehouse: COMPUTE_WH
+      role: TRANSFORMER

--- a/tests/test_dbt_cli.py
+++ b/tests/test_dbt_cli.py
@@ -1,0 +1,131 @@
+"""Tests for `scherlok dbt` CLI command."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from scherlok.cli import app
+
+runner = CliRunner()
+FIXTURES = Path(__file__).parent / "fixtures" / "dbt"
+PG_PROJECT = FIXTURES / "jaffle_shop_postgres"
+PROFILES_PG = FIXTURES / "profiles_postgres"
+
+
+def test_dbt_help():
+    result = runner.invoke(app, ["dbt", "--help"])
+    assert result.exit_code == 0
+    assert "Profile and watch dbt models" in result.output
+
+
+def test_dbt_missing_manifest():
+    """Pointing at a non-dbt directory should fail with a clear message."""
+    result = runner.invoke(app, ["dbt", "--project-dir", "/tmp/nonexistent-dbt-project"])
+    assert result.exit_code == 1
+    assert "manifest.json not found" in result.output
+
+
+def test_dbt_select_filter_no_match():
+    """--select with a name that doesn't exist exits with a clear error."""
+    result = runner.invoke(
+        app,
+        [
+            "dbt",
+            "--project-dir", str(PG_PROJECT),
+            "--connection-string", "postgresql://u:p@host/db",
+            "--select", "ghost_model",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "No models matched" in result.output
+
+
+@patch("scherlok.cli.get_connector")
+def test_dbt_with_explicit_connection(mock_get_connector, tmp_path, monkeypatch):
+    """End-to-end: explicit --connection-string skips profiles.yml entirely."""
+    # Force config to live in tmp_path so we don't pollute ~/.scherlok
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    fake = MagicMock()
+    fake.connect.return_value = True
+    # Match dbt model identifiers exactly
+    fake.list_tables.return_value = [
+        "stg_customers", "stg_orders", "fct_orders", "dim_customers_inc",
+    ]
+    mock_get_connector.return_value = fake
+
+    with patch("scherlok.cli._watch_table") as mock_watch:
+        mock_watch.return_value = ([], {"row_count": 100})
+        result = runner.invoke(
+            app,
+            [
+                "dbt",
+                "--project-dir", str(PG_PROJECT),
+                "--connection-string", "postgresql://u:p@host/db",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    # 4 materialized models in the postgres fixture
+    assert mock_watch.call_count == 4
+    assert "Summary:" in result.output
+
+
+@patch("scherlok.cli.get_connector")
+def test_dbt_resolves_from_profiles(mock_get_connector, tmp_path, monkeypatch):
+    """When --connection-string is omitted, profiles.yml drives resolution."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("PG_USER", "alice")
+    monkeypatch.setenv("PG_PASSWORD", "wonderland")
+
+    fake = MagicMock()
+    fake.connect.return_value = True
+    fake.list_tables.return_value = [
+        "stg_customers", "stg_orders", "fct_orders", "dim_customers_inc",
+    ]
+    mock_get_connector.return_value = fake
+
+    with patch("scherlok.cli._watch_table") as mock_watch:
+        mock_watch.return_value = ([], {"row_count": 50})
+        result = runner.invoke(
+            app,
+            [
+                "dbt",
+                "--project-dir", str(PG_PROJECT),
+                "--profiles-dir", str(PROFILES_PG),
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    mock_get_connector.assert_called_with(
+        "postgresql://alice:wonderland@localhost:5432/jaffle_db"
+    )
+
+
+@patch("scherlok.cli.get_connector")
+def test_dbt_select_filters_models(mock_get_connector, tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    fake = MagicMock()
+    fake.connect.return_value = True
+    fake.list_tables.return_value = ["stg_customers", "stg_orders", "fct_orders"]
+    mock_get_connector.return_value = fake
+
+    with patch("scherlok.cli._watch_table") as mock_watch:
+        mock_watch.return_value = ([], {"row_count": 1})
+        result = runner.invoke(
+            app,
+            [
+                "dbt",
+                "--project-dir", str(PG_PROJECT),
+                "--connection-string", "postgresql://u:p@h/d",
+                "--select", "fct_orders",
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert mock_watch.call_count == 1
+    # Exactly fct_orders profiled
+    called_table = mock_watch.call_args.args[2]
+    assert called_table == "fct_orders"

--- a/tests/test_dbt_manifest.py
+++ b/tests/test_dbt_manifest.py
@@ -1,0 +1,98 @@
+"""Tests for scherlok.dbt.manifest — manifest.json parser."""
+
+from pathlib import Path
+
+import pytest
+
+from scherlok.dbt.manifest import (
+    discover_models,
+    discover_sources,
+    load_manifest,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures" / "dbt"
+PG_PROJECT = FIXTURES / "jaffle_shop_postgres"
+SF_PROJECT = FIXTURES / "jaffle_shop_snowflake"
+OLD_PROJECT = FIXTURES / "jaffle_shop_old"
+
+
+def test_load_manifest_valid():
+    manifest = load_manifest(PG_PROJECT)
+    assert manifest["metadata"]["adapter_type"] == "postgres"
+    assert "nodes" in manifest
+
+
+def test_load_manifest_missing_file(tmp_path):
+    with pytest.raises(FileNotFoundError, match="manifest.json not found"):
+        load_manifest(tmp_path)
+
+
+def test_load_manifest_old_version_rejected():
+    with pytest.raises(ValueError, match="manifest_version v8"):
+        load_manifest(OLD_PROJECT)
+
+
+def test_discover_models_filters_to_materialized():
+    """Ephemeral models, tests, and seeds must NOT be discovered."""
+    manifest = load_manifest(PG_PROJECT)
+    models = discover_models(manifest)
+    names = {m.name for m in models}
+
+    assert "stg_customers" in names  # view
+    assert "stg_orders" in names  # view
+    assert "fct_orders" in names  # table
+    assert "dim_customers_inc" in names  # incremental
+
+    assert "int_orders_pivoted" not in names  # ephemeral — skipped
+    assert "unique_stg_customers_id" not in names  # test — skipped
+    assert "raw_customers" not in names  # seed — skipped
+
+
+def test_discover_models_postgres_naming():
+    manifest = load_manifest(PG_PROJECT)
+    models = discover_models(manifest)
+    fct = next(m for m in models if m.name == "fct_orders")
+    assert fct.adapter == "postgres"
+    assert fct.schema == "public"
+    assert fct.identifier == "fct_orders"
+    assert fct.materialized == "table"
+
+
+def test_discover_models_snowflake_quoted():
+    """Snowflake aliases are typically uppercase."""
+    manifest = load_manifest(SF_PROJECT)
+    models = discover_models(manifest)
+    assert len(models) == 1
+    m = models[0]
+    assert m.adapter == "snowflake"
+    assert m.identifier == "STG_ORDERS"
+    assert m.name == "stg_orders"
+    assert m.schema == "PUBLIC"
+
+
+def test_discover_sources():
+    manifest = load_manifest(PG_PROJECT)
+    sources = discover_sources(manifest)
+    assert len(sources) == 1
+    s = sources[0]
+    assert s.resource_type == "source"
+    assert s.identifier == "raw_payments"
+    assert s.name == "payments"
+    assert s.schema == "raw"
+
+
+def test_discover_sources_empty_when_none():
+    manifest = load_manifest(SF_PROJECT)
+    assert discover_sources(manifest) == []
+
+
+def test_load_manifest_unsupported_adapter(tmp_path):
+    """An adapter outside postgres/bigquery/snowflake should raise."""
+    target = tmp_path / "target"
+    target.mkdir()
+    (target / "manifest.json").write_text(
+        '{"metadata": {"dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",'
+        '"adapter_type": "redshift"}, "nodes": {}, "sources": {}}'
+    )
+    with pytest.raises(ValueError, match="Unsupported dbt adapter 'redshift'"):
+        load_manifest(tmp_path)

--- a/tests/test_dbt_profiles.py
+++ b/tests/test_dbt_profiles.py
@@ -1,0 +1,107 @@
+"""Tests for scherlok.dbt.profiles — connection string resolution from profiles.yml."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from scherlok.dbt.profiles import ProfileResolutionError, resolve_connection_string
+
+FIXTURES = Path(__file__).parent / "fixtures" / "dbt"
+PG_PROJECT = FIXTURES / "jaffle_shop_postgres"
+SF_PROJECT = FIXTURES / "jaffle_shop_snowflake"
+
+PROFILES_PG = FIXTURES / "profiles_postgres"
+PROFILES_BQ = FIXTURES / "profiles_bigquery"
+PROFILES_SF = FIXTURES / "profiles_snowflake"
+
+
+def test_resolve_postgres_profile(monkeypatch):
+    monkeypatch.setenv("PG_USER", "alice")
+    monkeypatch.setenv("PG_PASSWORD", "wonderland")
+    conn = resolve_connection_string(PG_PROJECT, profiles_dir=PROFILES_PG)
+    assert conn == "postgresql://alice:wonderland@localhost:5432/jaffle_db"
+
+
+def test_resolve_postgres_uses_env_var_default(monkeypatch):
+    """env_var('PG_USER', 'jaffle') must fall back to the literal default."""
+    monkeypatch.delenv("PG_USER", raising=False)
+    monkeypatch.delenv("PG_PASSWORD", raising=False)
+    conn = resolve_connection_string(PG_PROJECT, profiles_dir=PROFILES_PG)
+    assert conn == "postgresql://jaffle:secret@localhost:5432/jaffle_db"
+
+
+def test_resolve_postgres_target_override(monkeypatch):
+    monkeypatch.delenv("PG_USER", raising=False)
+    conn = resolve_connection_string(PG_PROJECT, profiles_dir=PROFILES_PG, target="prod")
+    assert conn == "postgresql://prod_user:prod_pw@prod-host:5432/jaffle_prod"
+
+
+def test_resolve_bigquery_profile(monkeypatch):
+    # bigquery profile uses jaffle_shop_postgres dbt_project.yml (same `profile:` name)
+    conn = resolve_connection_string(PG_PROJECT, profiles_dir=PROFILES_BQ)
+    assert conn == "bigquery://my-gcp-project/jaffle_shop"
+
+
+def test_resolve_snowflake_profile(monkeypatch):
+    monkeypatch.setenv("SF_USER", "robson")
+    monkeypatch.setenv("SF_PASSWORD", "elementary")
+    conn = resolve_connection_string(SF_PROJECT, profiles_dir=PROFILES_SF)
+    assert conn == "snowflake://my-account.us-east-1/ANALYTICS/PUBLIC"
+
+
+def test_unsupported_adapter_raises(tmp_path):
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / "dbt_project.yml").write_text("name: x\nprofile: x\n")
+    profiles = tmp_path / "profiles"
+    profiles.mkdir()
+    (profiles / "profiles.yml").write_text(
+        "x:\n  target: dev\n  outputs:\n    dev:\n      type: redshift\n      host: rs\n"
+    )
+    with pytest.raises(ProfileResolutionError, match="Unsupported dbt adapter 'redshift'"):
+        resolve_connection_string(project, profiles_dir=profiles)
+
+
+def test_missing_dbt_project_yml(tmp_path):
+    with pytest.raises(ProfileResolutionError, match="dbt_project.yml not found"):
+        resolve_connection_string(tmp_path, profiles_dir=PROFILES_PG)
+
+
+def test_missing_profiles_yml(tmp_path):
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / "dbt_project.yml").write_text("name: x\nprofile: x\n")
+    with pytest.raises(ProfileResolutionError, match="profiles.yml not found"):
+        resolve_connection_string(project, profiles_dir=tmp_path / "missing")
+
+
+def test_dbt_profiles_dir_env_var(monkeypatch):
+    """When --profiles-dir is None and DBT_PROFILES_DIR is set, the env var wins."""
+    monkeypatch.setenv("DBT_PROFILES_DIR", str(PROFILES_PG))
+    monkeypatch.setenv("PG_USER", "envalice")
+    monkeypatch.setenv("PG_PASSWORD", "envpw")
+    # profiles_dir=None, DBT_PROFILES_DIR is the resolution path
+    conn = resolve_connection_string(PG_PROJECT, profiles_dir=None)
+    assert conn == "postgresql://envalice:envpw@localhost:5432/jaffle_db"
+    assert os.environ["DBT_PROFILES_DIR"]  # safety check
+
+
+def test_target_not_found(tmp_path):
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / "dbt_project.yml").write_text("name: x\nprofile: x\n")
+    profiles = tmp_path / "profiles"
+    profiles.mkdir()
+    (profiles / "profiles.yml").write_text(
+        "x:\n"
+        "  target: dev\n"
+        "  outputs:\n"
+        "    dev:\n"
+        "      type: postgres\n"
+        "      host: localhost\n"
+        "      user: u\n"
+        "      dbname: d\n"
+    )
+    with pytest.raises(ProfileResolutionError, match="Target 'staging' not found"):
+        resolve_connection_string(project, profiles_dir=profiles, target="staging")


### PR DESCRIPTION
## Summary

Pre-launch dbt integration (defensibilidade vs. Elementary/re_data no HN). Novo comando `scherlok dbt` que lê `target/manifest.json`, descobre modelos materializados e roda investigate+watch por modelo, reusando os connectors existentes (Postgres/BigQuery/Snowflake).

Posicionamento: **"Scherlok complementa `dbt test` com detecção automática"**.

## What changed

**New module `scherlok.dbt`:**
- `manifest.py` — parser de `target/manifest.json` com validação de schema (`manifest_version >= 10`, dbt 1.6+) e filtro pra `materialized in {table, incremental, view, materialized_view}`. Skipa `ephemeral`, tests, seeds, snapshots.
- `profiles.py` — resolve connection string a partir de `profiles.yml` (postgres/bigquery/snowflake). Renderiza `{{ env_var('NAME', 'default') }}`. Outros adapters → erro amigável apontando pra `--connection-string`.

**CLI:** novo comando `scherlok dbt`:
```
scherlok dbt --project-dir <path>
             [--profiles-dir <path>] [--target <name>]
             [--connection-string <str>]   # bypass profiles.yml
             [--select <model> -s ...]      # filtra modelos
             [--include-sources]            # também perfila sources
             [--webhook <url>] [--email <e>]
             [--fail-on critical|warning]
```

**Refator interno:** extraí `_watch_table()` e `_dispatch_alerts()` de `_run_watch()` pra permitir output dbt-style ✓/✗ por modelo. `watch` e `ci` continuam idênticos do ponto de vista do usuário.

**Optional dep:** `pip install scherlok[dbt]` adiciona apenas `pyyaml` — nada de `dbt-core` em runtime.

## Output exemplo

```
Investigating 4 dbt models in ./my_dbt_project (postgres)
  ✓ stg_customers                  (12,345 rows)
  ✓ stg_orders                     (98,765 rows)
  ✗ fct_orders                     CRITICAL: Row count dropped 42%
  ✓ dim_customers_inc              (12,300 rows)

Summary: 4 profiled, 1 anomalies (1 critical, 0 warning)
```

## What's NOT in this PR (Mês 5)

Escopo deliberadamente reduzido pra não atrasar launch:
- ❌ GitHub Action (`uses: rbmuller/scherlok-action@v1`)
- ❌ `scherlok dbt run-and-watch` wrapper
- ❌ Lineage tree ASCII via `parent_map` / `child_map`
- ❌ JSON output estruturado (`--output json`)

## Test plan

- [x] `ruff check src/ tests/` — passing
- [x] `pytest` — 147 passed (122 existentes + 25 novos)
- [x] Cobertura: manifest parser (9 testes), profiles resolver (10 testes), CLI command (6 testes com mocks)
- [x] Fixtures realistas: `jaffle_shop` postgres + snowflake + manifest antigo (rejeição de versão)
- [x] `scherlok dbt --help` aparece corretamente no CLI
- [ ] Smoke test manual contra projeto dbt real (jaffle_shop com Postgres) — Robson/sr-dev a fazer antes do merge

## Links

- ROADMAP item: [Month 4 (May 2026) — dbt v0](docs/ROADMAP.md) (gitignored, mas cobre escopo)
- Doc completa local: `docs/dbt-integration.md` (gitignored — discutir se queremos publicar)