### PR TITLE
fix: include views in list_tables (#7) + dbt smoke test demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Views were silently skipped** by `scherlok investigate`/`watch`/`dbt` on Postgres and Snowflake (`list_tables` filtered to `BASE TABLE` only). Materialized dbt views (`materialized: view`, the default for `staging/` models in layered dbt projects) are now discovered. ([#7](https://github.com/rbmuller/scherlok/issues/7))
+
 ### Added
 - **dbt integration v0** — new `scherlok dbt` command. Reads `target/manifest.json`, discovers materialized models (`table`/`incremental`/`view`/`materialized_view`), auto-resolves the connection from `profiles.yml` (postgres / bigquery / snowflake), and runs investigate + watch per model with dbt-style ✓/✗ output.
   - Optional dependency: `pip install scherlok[dbt]` (adds PyYAML)

--- a/examples/dbt_smoke/.gitignore
+++ b/examples/dbt_smoke/.gitignore
@@ -1,0 +1,5 @@
+target/
+dbt_packages/
+logs/
+.venv-dbt/
+.user.yml

--- a/examples/dbt_smoke/README.md
+++ b/examples/dbt_smoke/README.md
@@ -1,0 +1,48 @@
+# dbt Smoke Test
+
+A minimal dbt project used to validate `scherlok dbt` end-to-end against a real Postgres + real dbt manifest. Use it as a starting point if you're contributing or just want to see the integration in action.
+
+## What's here
+
+- `dbt_project.yml` / `profiles.yml` — points at the local Postgres seeded by [`../docker-compose.yml`](../docker-compose.yml)
+- `models/staging/stg_users.sql` — view (smoke-tests view discovery, see issue #7)
+- `models/marts/fct_orders.sql` — table (smoke-tests volume drop detection)
+- `models/marts/dim_products.sql` — table
+
+## Run it
+
+dbt-core requires Python 3.10–3.12 (not 3.13/3.14), so use a separate venv if your main scherlok venv is on a newer version.
+
+```bash
+# 1. Boot the seeded Postgres
+cd examples
+docker compose up -d
+
+# 2. Install dbt-postgres in a 3.11 venv
+cd dbt_smoke
+pyenv shell 3.11.8     # or any 3.10–3.12
+python -m venv .venv-dbt
+source .venv-dbt/bin/activate
+pip install "dbt-postgres>=1.8"
+
+# 3. Generate the manifest
+DBT_PROFILES_DIR=. dbt run
+
+# 4. Run scherlok against the manifest (use your scherlok venv here)
+deactivate
+scherlok dbt --project-dir . --profiles-dir .
+```
+
+You should see all 3 models profiled with `✓` on the first run.
+
+## Force an anomaly
+
+```bash
+docker exec examples-postgres-1 \
+    psql -U scherlok -d demo -c "DELETE FROM orders WHERE id > 5;"
+
+DBT_PROFILES_DIR=. dbt run --select fct_orders
+scherlok dbt --project-dir . --profiles-dir . --fail-on critical
+```
+
+Expected: `fct_orders` shows `✗ CRITICAL: Row count dropped 60.0% (10 -> 4)` and the command exits with status 1.

--- a/examples/dbt_smoke/dbt_project.yml
+++ b/examples/dbt_smoke/dbt_project.yml
@@ -1,0 +1,13 @@
+name: smoke
+version: '1.0.0'
+profile: smoke
+config-version: 2
+
+model-paths: ["models"]
+target-path: "target"
+
+models:
+  smoke:
+    +materialized: table
+    staging:
+      +materialized: view

--- a/examples/dbt_smoke/models/marts/dim_products.sql
+++ b/examples/dbt_smoke/models/marts/dim_products.sql
@@ -1,0 +1,8 @@
+select
+    id,
+    name,
+    price,
+    category,
+    stock,
+    updated_at
+from {{ source('demo', 'products') }}

--- a/examples/dbt_smoke/models/marts/fct_orders.sql
+++ b/examples/dbt_smoke/models/marts/fct_orders.sql
@@ -1,0 +1,7 @@
+select
+    user_id,
+    count(*) as order_count,
+    sum(amount) as total_amount,
+    max(created_at) as last_order_at
+from {{ source('demo', 'orders') }}
+group by user_id

--- a/examples/dbt_smoke/models/staging/_sources.yml
+++ b/examples/dbt_smoke/models/staging/_sources.yml
@@ -1,0 +1,9 @@
+version: 2
+
+sources:
+  - name: demo
+    schema: public
+    tables:
+      - name: users
+      - name: orders
+      - name: products

--- a/examples/dbt_smoke/models/staging/stg_users.sql
+++ b/examples/dbt_smoke/models/staging/stg_users.sql
@@ -1,0 +1,7 @@
+select
+    id,
+    name,
+    email,
+    plan,
+    created_at
+from {{ source('demo', 'users') }}

--- a/examples/dbt_smoke/profiles.yml
+++ b/examples/dbt_smoke/profiles.yml
@@ -1,0 +1,12 @@
+smoke:
+  target: dev
+  outputs:
+    dev:
+      type: postgres
+      host: localhost
+      port: 5433
+      user: scherlok
+      password: scherlok
+      dbname: demo
+      schema: public
+      threads: 1

--- a/src/scherlok/connectors/postgres.py
+++ b/src/scherlok/connectors/postgres.py
@@ -30,11 +30,12 @@ class PostgresConnector(BaseConnector):
         return self._conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
 
     def list_tables(self) -> list[str]:
-        """List all user tables in the public schema."""
+        """List all user tables and views in the public schema."""
         with self._cursor() as cur:
             cur.execute(
                 "SELECT table_name FROM information_schema.tables "
-                "WHERE table_schema = 'public' AND table_type = 'BASE TABLE' "
+                "WHERE table_schema = 'public' "
+                "AND table_type IN ('BASE TABLE', 'VIEW') "
                 "ORDER BY table_name"
             )
             return [row["table_name"] for row in cur.fetchall()]

--- a/src/scherlok/connectors/snowflake.py
+++ b/src/scherlok/connectors/snowflake.py
@@ -84,11 +84,11 @@ class SnowflakeConnector(BaseConnector):
         return rows
 
     def list_tables(self) -> list[str]:
-        """List all tables in the schema (excludes views)."""
+        """List all tables and views in the schema."""
         sql = (
             f"SELECT table_name FROM {self._database}.information_schema.tables "
             f"WHERE table_schema = '{self._schema.upper()}' "
-            f"AND table_type = 'BASE TABLE' "
+            f"AND table_type IN ('BASE TABLE', 'VIEW') "
             f"ORDER BY table_name"
         )
         rows = self._query(sql)

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -1,0 +1,58 @@
+"""Tests for the Postgres connector using mocks."""
+
+from unittest.mock import MagicMock, patch
+
+
+def _make_connector_with_mock_cursor(rows: list[dict]) -> tuple[object, MagicMock]:
+    """Build a PostgresConnector whose cursor returns the given rows."""
+    from scherlok.connectors.postgres import PostgresConnector
+
+    cur = MagicMock()
+    cur.fetchall.return_value = rows
+    cur.__enter__ = MagicMock(return_value=cur)
+    cur.__exit__ = MagicMock(return_value=False)
+
+    conn = MagicMock()
+    conn.cursor.return_value = cur
+
+    c = PostgresConnector("postgresql://u:p@h/d")
+    c._conn = conn
+    return c, cur
+
+
+def test_list_tables_query_includes_views():
+    """Issue #7: list_tables must return both BASE TABLE and VIEW rows."""
+    c, cur = _make_connector_with_mock_cursor(
+        [
+            {"table_name": "fct_orders"},  # BASE TABLE
+            {"table_name": "stg_users"},  # VIEW
+        ]
+    )
+    tables = c.list_tables()
+    assert "stg_users" in tables
+    assert "fct_orders" in tables
+
+    # Query must filter to ('BASE TABLE', 'VIEW')
+    sql = cur.execute.call_args.args[0]
+    assert "'BASE TABLE'" in sql
+    assert "'VIEW'" in sql
+
+
+@patch("scherlok.connectors.postgres.psycopg2.connect")
+def test_connect_success(mock_connect):
+    from scherlok.connectors.postgres import PostgresConnector
+
+    mock_connect.return_value = MagicMock()
+    c = PostgresConnector("postgresql://u:p@h/d")
+    assert c.connect() is True
+
+
+@patch("scherlok.connectors.postgres.psycopg2.connect")
+def test_connect_failure(mock_connect):
+    import psycopg2
+
+    from scherlok.connectors.postgres import PostgresConnector
+
+    mock_connect.side_effect = psycopg2.OperationalError("nope")
+    c = PostgresConnector("postgresql://u:p@h/d")
+    assert c.connect() is False

--- a/tests/test_snowflake.py
+++ b/tests/test_snowflake.py
@@ -43,6 +43,24 @@ class TestSnowflakeConnector:
         tables = c.list_tables()
         # Result is lowercased
         assert tables == ["users", "orders"]
+        # Regression for #7: query must include both BASE TABLE and VIEW
+        sql = mock_query.call_args.args[0]
+        assert "'BASE TABLE'" in sql and "'VIEW'" in sql
+
+    @patch("scherlok.connectors.snowflake.SnowflakeConnector._query")
+    def test_list_tables_includes_views(self, mock_query):
+        """Issue #7: views (e.g. dbt staging models) must be discoverable."""
+        from scherlok.connectors.snowflake import SnowflakeConnector
+
+        mock_query.return_value = [
+            {"table_name": "FCT_ORDERS"},  # table
+            {"table_name": "STG_USERS"},  # view
+        ]
+        c = SnowflakeConnector("snowflake://acc/db/schema")
+        c._conn = MagicMock()
+        tables = c.list_tables()
+        assert "stg_users" in tables
+        assert "fct_orders" in tables
 
     @patch("scherlok.connectors.snowflake.SnowflakeConnector._query")
     def test_get_columns(self, mock_query):


### PR DESCRIPTION
Closes #7.

## Problem

`scherlok dbt` silently skipped any dbt model materialized as a `view` on Postgres and Snowflake. This was discovered while running the smoke test for the dbt v0 PR (#6). With models like `stg_users` (the canonical dbt staging-as-view pattern), output was:

\`\`\`
Investigating 2 dbt models in examples/dbt_smoke (postgres)
Skipped 1 not found in postgres: stg_users
  ✓ dim_products  (5 rows)
  ✓ fct_orders    (10 rows)
\`\`\`

## Fix

Both connectors filtered to `WHERE table_type = 'BASE TABLE'`. Changed to `IN ('BASE TABLE', 'VIEW')`. Verified the other connector methods are view-safe:

| Method | View-safe? | Notes |
|---|---|---|
| `get_row_count` | ✅ | `SELECT count(*) FROM "view"` |
| `get_columns` | ✅ | `information_schema.columns` includes views |
| `get_column_stats` | ✅ | aggregates work on views |
| `get_last_modified` | ⚠️ | returns `None` for views (acceptable — views are derived; freshness comes from underlying tables) |

BigQuery's SDK `client.list_tables()` already returns views by default, so no change needed there.

## Demo project

Adds `examples/dbt_smoke/` — a minimal dbt project (3 models: 1 view + 2 tables) that contributors can use to reproduce the issue/fix end-to-end against the existing seeded Postgres in `examples/docker-compose.yml`. README walks through setup, baseline run, and forced anomaly.

## Smoke test re-run with this fix

\`\`\`
Investigating 3 dbt models in examples/dbt_smoke (postgres)
  ✓ stg_users      (10 rows)   ← previously skipped
  ✓ dim_products   (5 rows)
  ✓ fct_orders     (10 rows)
\`\`\`

## Test plan

- [x] \`ruff check src/ tests/\` — passing
- [x] \`pytest\` — 151 passed (4 new regression tests in test_postgres.py and test_snowflake.py)
- [x] Smoke test: 3 models discovered (was 2), volume drop on fct_orders still triggers CRITICAL + exit 1