### PR TITLE
chore: pre-launch polish — connector hints + verbosity flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **`--verbose` / `-v` and `--quiet` / `-q` global flags** added to all commands. `--quiet` silences progress chatter while keeping anomaly results and errors (CI-friendly). `--verbose` adds per-table profiling timings and column counts.
+- **Connector error messages now include actionable hints.** `Failed to connect.` is followed by a one-line explanation of what went wrong, plus a hint when applicable.
+  - **Postgres:** classifies "connection refused" / "auth failed" / "database does not exist" / "SSL required" / timeout / unknown host
+  - **Snowflake:** detects missing `SNOWFLAKE_USER` / `SNOWFLAKE_PASSWORD`, missing python connector, auth failures, account/warehouse/database not found
+  - **BigQuery:** detects missing google-cloud-bigquery, missing Application Default Credentials, permission denied, project/dataset not found, billing not enabled
+
 ### Added
 - **HTML dashboard** — new `scherlok dashboard` command. Generates a self-contained HTML report (~28 KB) from the local profile store: KPIs, per-table incidents grouped with summary/threshold/first-seen, schema-drift `+`/`-`/`~` diff, sparklines, and history. Auto dark/light theme via `prefers-color-scheme` (`--theme dark|light` to override). No external URLs in the rendered file — works offline, screenshot-friendly.
   - Adds `jinja2>=3.0` to core dependencies

--- a/src/scherlok/cli.py
+++ b/src/scherlok/cli.py
@@ -1,5 +1,6 @@
 """CLI entry point for Scherlok. Built with Typer and Rich."""
 
+import time
 from pathlib import Path
 
 import typer
@@ -19,6 +20,9 @@ from scherlok.detector.distribution_shift import detect_distribution_shift
 from scherlok.detector.freshness import detect_freshness_anomalies
 from scherlok.detector.nullability import detect_nullability_anomalies
 from scherlok.detector.schema_drift import detect_schema_drift
+from scherlok.output import error as out_error
+from scherlok.output import info as out_info
+from scherlok.output import is_quiet, verbose_info
 from scherlok.profiler.distribution import profile_distribution
 from scherlok.profiler.freshness import profile_freshness
 from scherlok.profiler.schema import profile_schema
@@ -34,6 +38,22 @@ app = typer.Typer(
 console = Console()
 
 
+@app.callback()
+def _root_callback(
+    verbose: bool = typer.Option(
+        False, "--verbose", "-v",
+        help="Show detailed progress (per-table timings, query previews).",
+    ),
+    quiet: bool = typer.Option(
+        False, "--quiet", "-q",
+        help="Suppress non-essential output. Errors and exit codes still surface.",
+    ),
+) -> None:
+    """Root callback: wire global verbosity flags into scherlok.output."""
+    from scherlok.output import set_verbosity
+    set_verbosity(verbose=verbose, quiet=quiet)
+
+
 def _get_connector_or_exit() -> object:
     """Load config and return a connected connector, or exit with error."""
     cfg = ScherlokConfig.load()
@@ -46,9 +66,17 @@ def _get_connector_or_exit() -> object:
         raise typer.Exit(code=1)
     connector = get_connector(conn_str)
     if not connector.connect():
-        console.print("[red]Failed to connect to the database.[/red]")
+        _print_connect_failure(connector)
         raise typer.Exit(code=1)
     return connector
+
+
+def _print_connect_failure(connector: object) -> None:
+    """Render a 'failed to connect' header plus connector.last_error if available."""
+    console.print("[red]Failed to connect to the database.[/red]")
+    err = getattr(connector, "last_error", None)
+    if err:
+        console.print(f"  [dim]{err}[/dim]")
 
 
 @app.command()
@@ -73,7 +101,7 @@ def connect(
         tables = connector.list_tables()
         console.print(f"[green]Connected successfully.[/green] Found {len(tables)} tables.")
     else:
-        console.print("[red]Connection failed.[/red] Check your connection string.")
+        _print_connect_failure(connector)
         raise typer.Exit(code=1)
 
 
@@ -116,13 +144,14 @@ def investigate() -> None:
         tables = connector.list_tables()
 
         if not tables:
-            console.print("[yellow]No tables found.[/yellow]")
+            out_info("[yellow]No tables found.[/yellow]")
             raise typer.Exit(code=0)
 
-        console.print(f"Investigating [bold]{len(tables)}[/bold] tables...")
+        out_info(f"Investigating [bold]{len(tables)}[/bold] tables...")
 
         for table in tables:
-            console.print(f"  Profiling [cyan]{table}[/cyan]...")
+            t_start = time.perf_counter()
+            out_info(f"  Profiling [cyan]{table}[/cyan]...")
 
             vol = profile_volume(connector, table)
             store.save_profile(table, "volume", vol)
@@ -137,7 +166,13 @@ def investigate() -> None:
                 dist = profile_distribution(connector, table, col["name"])
                 store.save_profile(table, f"distribution:{col['name']}", dist)
 
-        console.print(
+            verbose_info(
+                f"{table}: {vol.get('row_count', 0)} rows · "
+                f"{len(sch.get('columns', []))} cols · "
+                f"{time.perf_counter() - t_start:.2f}s"
+            )
+
+        out_info(
             f"[green]Investigation complete.[/green] {len(tables)} tables profiled."
         )
 
@@ -198,20 +233,23 @@ def _dispatch_alerts(
 ) -> None:
     """Persist anomalies and fan out to webhook/email alerters."""
     if not anomalies:
-        console.print("[green]No anomalies detected.[/green]")
+        out_info("[green]No anomalies detected.[/green]")
         return
     store.save_anomalies(anomalies)
-    print_anomalies(anomalies)
+    if not is_quiet():
+        print_anomalies(anomalies)
     if webhook:
         ok = send_webhook(webhook, anomalies)
-        console.print(
-            "[dim]Webhook sent.[/dim]" if ok else "[red]Webhook delivery failed.[/red]"
-        )
+        if ok:
+            verbose_info("Webhook delivered.")
+        else:
+            out_error("[red]Webhook delivery failed.[/red]")
     if emails:
         ok = send_email_alert(emails, anomalies)
-        console.print(
-            "[dim]Email sent.[/dim]" if ok else "[red]Email delivery failed.[/red]"
-        )
+        if ok:
+            verbose_info("Email delivered.")
+        else:
+            out_error("[red]Email delivery failed.[/red]")
 
 
 def _run_watch(
@@ -237,7 +275,7 @@ def _run_watch(
             tables = connector.list_tables()
         all_anomalies: list[dict] = []
 
-        console.print(f"Watching [bold]{len(tables)}[/bold] tables...")
+        out_info(f"Watching [bold]{len(tables)}[/bold] tables...")
 
         for table in tables:
             anomalies, _ = _watch_table(connector, store, table)
@@ -306,7 +344,7 @@ def ci(
     # Validate connection
     connector = get_connector(connection_string)
     if not connector.connect():
-        console.print("[red]Failed to connect.[/red]")
+        _print_connect_failure(connector)
         raise typer.Exit(code=1)
 
     # Run watch (does profile + detect + alert in one)
@@ -416,7 +454,7 @@ def dbt(
 
     connector = get_connector(conn_str)
     if not connector.connect():
-        console.print("[red]Failed to connect using the resolved connection.[/red]")
+        _print_connect_failure(connector)
         raise typer.Exit(code=1)
 
     # 3. Match models to physical tables visible to the connector
@@ -430,12 +468,12 @@ def dbt(
         else:
             matched.append((node, physical))
 
-    console.print(
+    out_info(
         f"Investigating [bold]{len(matched)}[/bold] dbt {'nodes' if include_sources else 'models'} "
         f"in [cyan]{project_dir}[/cyan] ([dim]{adapter}[/dim])"
     )
     if missing:
-        console.print(
+        out_info(
             f"[yellow]Skipped {len(missing)} not found in {adapter}: "
             f"{', '.join(n.name for n in missing[:5])}"
             f"{' …' if len(missing) > 5 else ''}[/yellow]"
@@ -455,7 +493,7 @@ def dbt(
     # 5. Summary + exit code
     crit = sum(1 for a in all_anomalies if str(a.get("severity")).endswith("CRITICAL"))
     warn = sum(1 for a in all_anomalies if str(a.get("severity")).endswith("WARNING"))
-    console.print(
+    out_info(
         f"\n[bold]Summary:[/bold] {len(matched)} profiled, "
         f"{len(all_anomalies)} anomalies "
         f"([red]{crit} critical[/red], [yellow]{warn} warning[/yellow])"
@@ -490,18 +528,21 @@ def _resolve_physical_table(node: object, visible: set[str]) -> str | None:
 def _print_dbt_model_result(
     node: object, physical: str, current_vol: dict, anomalies: list[dict]
 ) -> None:
-    """Print one ✓/✗ line for a dbt model with row count or anomaly summary."""
+    """Print one ✓/✗ line for a dbt model with row count or anomaly summary.
+
+    ✓ rows respect --quiet (gone with quiet); ✗ rows always print so CI logs
+    surface the failures even on --quiet.
+    """
     name = node.name  # type: ignore[attr-defined]
     if not anomalies:
         rows = current_vol.get("row_count", "?")
-        console.print(f"  [green]✓[/green] {name:<30} ({rows:,} rows)")
+        out_info(f"  [green]✓[/green] {name:<30} ({rows:,} rows)")
         return
-    # Show the worst anomaly summary on the line
     severities = [str(a.get("severity")) for a in anomalies]
     worst = "CRITICAL" if any("CRITICAL" in s for s in severities) else "WARNING"
     color = "red" if worst == "CRITICAL" else "yellow"
     msg = anomalies[0].get("message", "anomaly detected")
-    console.print(f"  [{color}]✗[/{color}] {name:<30} {worst}: {msg}")
+    out_error(f"  [{color}]✗[/{color}] {name:<30} {worst}: {msg}")
 
 
 @app.command()

--- a/src/scherlok/connectors/base.py
+++ b/src/scherlok/connectors/base.py
@@ -9,10 +9,20 @@ class BaseConnector(ABC):
 
     def __init__(self, connection_string: str) -> None:
         self.connection_string = connection_string
+        self._last_error: str | None = None
+
+    @property
+    def last_error(self) -> str | None:
+        """Friendly, actionable description of the most recent failure, or None."""
+        return self._last_error
 
     @abstractmethod
     def connect(self) -> bool:
-        """Validate and establish a connection. Return True on success."""
+        """Validate and establish a connection. Return True on success.
+
+        On failure, implementations should set ``self._last_error`` to a
+        short, actionable string (no traceback) before returning False.
+        """
         ...
 
     @abstractmethod

--- a/src/scherlok/connectors/bigquery.py
+++ b/src/scherlok/connectors/bigquery.py
@@ -41,14 +41,55 @@ class BigQueryConnector(BaseConnector):
         """Validate connection to BigQuery."""
         try:
             from google.cloud import bigquery
+        except ImportError:
+            self._last_error = (
+                "google-cloud-bigquery not installed\n"
+                "  Hint: pip install scherlok[bigquery]"
+            )
+            return False
 
+        try:
             self._client = bigquery.Client(project=self._project)
             # Validate by listing tables (lightweight call)
             dataset_ref = self._client.dataset(self._dataset)
             list(self._client.list_tables(dataset_ref, max_results=1))
             return True
-        except Exception:
+        except Exception as exc:
+            self._last_error = self._classify_error(str(exc))
             return False
+
+    @staticmethod
+    def _classify_error(message: str) -> str:
+        """Map google-cloud-bigquery error text to a short, actionable hint."""
+        msg = message.strip()
+        lowered = msg.lower()
+        if (
+            "default credentials" in lowered
+            or "could not automatically determine credentials" in lowered
+        ):
+            return (
+                "Application Default Credentials not found\n"
+                "  Hint: gcloud auth application-default login"
+            )
+        if "permission denied" in lowered or "forbidden" in lowered or "403" in lowered:
+            return (
+                "permission denied — the authenticated identity lacks access to this dataset\n"
+                "  Hint: grant `roles/bigquery.dataViewer` and `roles/bigquery.jobUser`"
+            )
+        if "not found" in lowered and "dataset" in lowered:
+            return (
+                "dataset not found — check the dataset name and project\n"
+                "  Hint: bigquery://<project>/<dataset>"
+            )
+        if "not found" in lowered and "project" in lowered:
+            return "project not found — check the project ID in your connection string"
+        if "billing" in lowered:
+            return (
+                "billing not enabled on the project\n"
+                "  Hint: enable billing in the GCP console for this project"
+            )
+        first_line = msg.splitlines()[0] if msg else "unknown error"
+        return first_line
 
     def _query(self, sql: str) -> list[dict]:
         """Execute a query and return results as list of dicts."""

--- a/src/scherlok/connectors/postgres.py
+++ b/src/scherlok/connectors/postgres.py
@@ -22,8 +22,39 @@ class PostgresConnector(BaseConnector):
             self._conn = psycopg2.connect(self.connection_string)
             self._conn.autocommit = True
             return True
-        except psycopg2.Error:
+        except psycopg2.Error as exc:
+            self._last_error = self._classify_error(str(exc))
             return False
+
+    @staticmethod
+    def _classify_error(message: str) -> str:
+        """Map psycopg2 error text to a short, actionable hint."""
+        msg = message.strip()
+        lowered = msg.lower()
+        if "could not connect to server" in lowered or "connection refused" in lowered:
+            return (
+                "connection refused — is the server reachable?\n"
+                "  Hint: docker compose ps  /  pg_isready -h <host> -p <port>"
+            )
+        if "password authentication failed" in lowered or "authentication failed" in lowered:
+            return "wrong username or password — check the credentials in your connection string"
+        if "does not exist" in lowered and "database" in lowered:
+            return (
+                "database does not exist on the server\n"
+                "  Hint: list databases with `psql -l -h <host> -p <port>`"
+            )
+        if "ssl" in lowered and "required" in lowered:
+            return (
+                "server requires SSL\n"
+                "  Hint: append `?sslmode=require` to the connection string"
+            )
+        if "timeout" in lowered:
+            return "connection timed out — check the host/port and any firewall in front"
+        if "no such host" in lowered or "name or service not known" in lowered:
+            return "host not found — check the hostname in your connection string"
+        # Fallback: the raw message, trimmed and de-newlined for readability
+        first_line = msg.splitlines()[0] if msg else "unknown error"
+        return f"{first_line}"
 
     def _cursor(self) -> Any:
         """Return a dict cursor."""

--- a/src/scherlok/connectors/snowflake.py
+++ b/src/scherlok/connectors/snowflake.py
@@ -44,16 +44,32 @@ class SnowflakeConnector(BaseConnector):
 
     def connect(self) -> bool:
         """Validate and establish connection to Snowflake."""
+        import os
+
         try:
-            import os
-
             import snowflake.connector
+        except ImportError:
+            self._last_error = (
+                "snowflake-connector-python not installed\n"
+                "  Hint: pip install scherlok[snowflake]"
+            )
+            return False
 
-            user = os.environ.get("SNOWFLAKE_USER")
-            password = os.environ.get("SNOWFLAKE_PASSWORD")
-            if not user or not password:
-                return False
+        user = os.environ.get("SNOWFLAKE_USER")
+        password = os.environ.get("SNOWFLAKE_PASSWORD")
+        if not user or not password:
+            missing = []
+            if not user:
+                missing.append("SNOWFLAKE_USER")
+            if not password:
+                missing.append("SNOWFLAKE_PASSWORD")
+            self._last_error = (
+                f"missing required env var{'s' if len(missing) > 1 else ''}: {', '.join(missing)}\n"
+                f"  Hint: export {missing[0]}=... (and SNOWFLAKE_WAREHOUSE/ROLE if needed)"
+            )
+            return False
 
+        try:
             self._conn = snowflake.connector.connect(
                 account=self._account,
                 user=user,
@@ -69,8 +85,35 @@ class SnowflakeConnector(BaseConnector):
             cur.fetchone()
             cur.close()
             return True
-        except Exception:
+        except Exception as exc:
+            self._last_error = self._classify_error(str(exc))
             return False
+
+    @staticmethod
+    def _classify_error(message: str) -> str:
+        """Map Snowflake error text to a short, actionable hint."""
+        msg = message.strip()
+        lowered = msg.lower()
+        if "incorrect username or password" in lowered or "authentication" in lowered:
+            return (
+                "authentication failed — check SNOWFLAKE_USER and SNOWFLAKE_PASSWORD\n"
+                "  Hint: if your account has SSO/MFA, key-pair auth is required"
+            )
+        if "account" in lowered and ("not found" in lowered or "does not exist" in lowered):
+            return (
+                "account not found — check the connection string format\n"
+                "  Hint: snowflake://<account>/<database>/<schema> "
+                "(account looks like 'xy12345.us-east-1')"
+            )
+        if "warehouse" in lowered and ("not found" in lowered or "does not exist" in lowered):
+            return (
+                "warehouse not found — set SNOWFLAKE_WAREHOUSE to a valid warehouse\n"
+                "  Hint: SHOW WAREHOUSES in Snowflake to list available ones"
+            )
+        if "database" in lowered and "does not exist" in lowered:
+            return "database not found — check the database name in your connection string"
+        first_line = msg.splitlines()[0] if msg else "unknown error"
+        return first_line
 
     def _query(self, sql: str) -> list[dict]:
         """Execute a query and return results as list of dicts."""

--- a/src/scherlok/output.py
+++ b/src/scherlok/output.py
@@ -1,0 +1,58 @@
+"""Verbosity-aware print helpers.
+
+Layered on top of Rich's Console. Set verbosity once via `set_verbosity()`,
+then call `info()` / `verbose_info()` / `error()` from anywhere in the CLI.
+
+- `info(msg)` — printed unless `--quiet`. Default user-facing output.
+- `verbose_info(msg)` — printed only when `--verbose`. Diagnostics, timings.
+- `error(msg)` — always printed, regardless of `--quiet`. Failures and warnings.
+"""
+
+from rich.console import Console
+
+_console = Console()
+
+
+class _Verbosity:
+    verbose: bool = False
+    quiet: bool = False
+
+
+def set_verbosity(verbose: bool = False, quiet: bool = False) -> None:
+    """Configure the global verbosity. Mutually exclusive flags.
+
+    `--verbose` wins over `--quiet` if somehow both are set.
+    """
+    _Verbosity.verbose = verbose
+    _Verbosity.quiet = quiet and not verbose
+
+
+def is_verbose() -> bool:
+    return _Verbosity.verbose
+
+
+def is_quiet() -> bool:
+    return _Verbosity.quiet
+
+
+def info(msg: str) -> None:
+    """Default user-facing message. Suppressed by `--quiet`."""
+    if _Verbosity.quiet:
+        return
+    _console.print(msg)
+
+
+def verbose_info(msg: str) -> None:
+    """Diagnostic detail. Visible only with `--verbose`."""
+    if _Verbosity.verbose:
+        _console.print(f"[dim]· {msg}[/dim]")
+
+
+def error(msg: str) -> None:
+    """Error/warning message. Always printed, even with `--quiet`."""
+    _console.print(msg)
+
+
+def get_console() -> Console:
+    """Return the underlying Rich Console (for advanced cases like Tables)."""
+    return _console

--- a/tests/test_connector_errors.py
+++ b/tests/test_connector_errors.py
@@ -1,0 +1,180 @@
+"""Tests for the connector last_error hints introduced for v0.5.0 polish."""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _psycopg2_error(msg: str):
+    """Build a real psycopg2.Error subclass instance with the given message."""
+    import psycopg2
+    return psycopg2.OperationalError(msg)
+
+
+@patch("scherlok.connectors.postgres.psycopg2.connect")
+def test_postgres_connection_refused_hint(mock_connect):
+    from scherlok.connectors.postgres import PostgresConnector
+
+    mock_connect.side_effect = _psycopg2_error(
+        "could not connect to server: Connection refused\n"
+        '\tIs the server running on host "localhost" and accepting TCP/IP connections '
+        "on port 5432?"
+    )
+    c = PostgresConnector("postgresql://u:p@localhost:5432/db")
+    assert c.connect() is False
+    assert c.last_error is not None
+    assert "connection refused" in c.last_error.lower()
+    assert "Hint" in c.last_error
+
+
+@patch("scherlok.connectors.postgres.psycopg2.connect")
+def test_postgres_auth_failed_hint(mock_connect):
+    from scherlok.connectors.postgres import PostgresConnector
+
+    mock_connect.side_effect = _psycopg2_error(
+        'FATAL:  password authentication failed for user "alice"'
+    )
+    c = PostgresConnector("postgresql://alice:wrong@host/db")
+    assert c.connect() is False
+    assert "username or password" in (c.last_error or "")
+
+
+@patch("scherlok.connectors.postgres.psycopg2.connect")
+def test_postgres_database_not_found_hint(mock_connect):
+    from scherlok.connectors.postgres import PostgresConnector
+
+    mock_connect.side_effect = _psycopg2_error('FATAL:  database "nope" does not exist')
+    c = PostgresConnector("postgresql://u:p@host/nope")
+    assert c.connect() is False
+    assert "database does not exist" in (c.last_error or "").lower()
+
+
+@patch("scherlok.connectors.postgres.psycopg2.connect")
+def test_postgres_unknown_error_falls_back_to_first_line(mock_connect):
+    from scherlok.connectors.postgres import PostgresConnector
+
+    mock_connect.side_effect = _psycopg2_error("some bizarre internal error\nwith a 2nd line")
+    c = PostgresConnector("postgresql://u:p@host/db")
+    assert c.connect() is False
+    assert "bizarre internal error" in (c.last_error or "")
+    assert "2nd line" not in (c.last_error or "")
+
+
+def test_base_connector_starts_with_no_error():
+    from scherlok.connectors.postgres import PostgresConnector
+
+    c = PostgresConnector("postgresql://u:p@h/d")
+    assert c.last_error is None
+
+
+# --- Snowflake ---------------------------------------------------------------
+
+def test_snowflake_connector_not_installed_hint():
+    """When snowflake-connector-python isn't installed, last_error names the extra."""
+    # Ensure the module is NOT in sys.modules
+    sys.modules.pop("snowflake", None)
+    sys.modules.pop("snowflake.connector", None)
+
+    from scherlok.connectors.snowflake import SnowflakeConnector
+
+    c = SnowflakeConnector("snowflake://acc/db/schema")
+    assert c.connect() is False
+    err = c.last_error or ""
+    # If snowflake is not installed locally, we should hit the import-error branch
+    assert "scherlok[snowflake]" in err or "missing required env var" in err
+
+
+@pytest.fixture
+def fake_snowflake(monkeypatch):
+    """Inject a fake snowflake.connector module so connect() can proceed past import."""
+    fake_module = MagicMock()
+    fake_pkg = MagicMock()
+    fake_pkg.connector = fake_module
+    monkeypatch.setitem(sys.modules, "snowflake", fake_pkg)
+    monkeypatch.setitem(sys.modules, "snowflake.connector", fake_module)
+    return fake_module
+
+
+def test_snowflake_missing_env_vars(monkeypatch, fake_snowflake):
+    """When SNOWFLAKE_USER/PASSWORD aren't set, last_error names them."""
+    from scherlok.connectors.snowflake import SnowflakeConnector
+
+    monkeypatch.delenv("SNOWFLAKE_USER", raising=False)
+    monkeypatch.delenv("SNOWFLAKE_PASSWORD", raising=False)
+    c = SnowflakeConnector("snowflake://acc/db/schema")
+    assert c.connect() is False
+    err = c.last_error or ""
+    assert "SNOWFLAKE_USER" in err
+    assert "SNOWFLAKE_PASSWORD" in err
+
+
+def test_snowflake_auth_error_hint(monkeypatch, fake_snowflake):
+    from scherlok.connectors.snowflake import SnowflakeConnector
+
+    monkeypatch.setenv("SNOWFLAKE_USER", "alice")
+    monkeypatch.setenv("SNOWFLAKE_PASSWORD", "wrong")
+    fake_snowflake.connect.side_effect = Exception(
+        "Incorrect username or password was specified"
+    )
+    c = SnowflakeConnector("snowflake://acc/db/schema")
+    assert c.connect() is False
+    assert "authentication" in (c.last_error or "").lower()
+
+
+# --- BigQuery ----------------------------------------------------------------
+
+def test_bigquery_module_not_installed_hint():
+    """Without google-cloud-bigquery, last_error names the extra."""
+    sys.modules.pop("google", None)
+    sys.modules.pop("google.cloud", None)
+    sys.modules.pop("google.cloud.bigquery", None)
+
+    from scherlok.connectors.bigquery import BigQueryConnector
+
+    c = BigQueryConnector("bigquery://my-proj/my-dataset")
+    assert c.connect() is False
+    err = c.last_error or ""
+    # If bigquery is not installed locally, the import-error hint fires
+    assert "scherlok[bigquery]" in err or "credentials" in err.lower()
+
+
+@pytest.fixture
+def fake_bigquery(monkeypatch):
+    """Inject a fake google.cloud.bigquery module so connect() can proceed past import."""
+    fake_module = MagicMock()
+    fake_cloud = MagicMock()
+    fake_cloud.bigquery = fake_module
+    fake_google = MagicMock()
+    fake_google.cloud = fake_cloud
+    monkeypatch.setitem(sys.modules, "google", fake_google)
+    monkeypatch.setitem(sys.modules, "google.cloud", fake_cloud)
+    monkeypatch.setitem(sys.modules, "google.cloud.bigquery", fake_module)
+    return fake_module
+
+
+def test_bigquery_adc_missing_hint(fake_bigquery):
+    fake_bigquery.Client.side_effect = Exception(
+        "Could not automatically determine credentials. "
+        "Please set GOOGLE_APPLICATION_CREDENTIALS or run gcloud auth"
+    )
+    from scherlok.connectors.bigquery import BigQueryConnector
+
+    c = BigQueryConnector("bigquery://my-proj/my-dataset")
+    assert c.connect() is False
+    err = c.last_error or ""
+    assert "Application Default Credentials" in err
+    assert "gcloud auth application-default login" in err
+
+
+def test_bigquery_dataset_not_found_hint(fake_bigquery):
+    client_instance = MagicMock()
+    client_instance.list_tables.side_effect = Exception(
+        "Not found: Dataset my-proj:nope was not found"
+    )
+    fake_bigquery.Client.return_value = client_instance
+    from scherlok.connectors.bigquery import BigQueryConnector
+
+    c = BigQueryConnector("bigquery://my-proj/nope")
+    assert c.connect() is False
+    assert "dataset not found" in (c.last_error or "").lower()

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,60 @@
+"""Tests for verbosity helpers in scherlok.output."""
+
+from io import StringIO
+
+from rich.console import Console
+
+import scherlok.output as out
+
+
+def _capture():
+    """Replace the module-level console with one that writes to StringIO."""
+    buf = StringIO()
+    out._console = Console(file=buf, force_terminal=False, width=200)
+    return buf
+
+
+def setup_function():
+    """Reset verbosity between tests."""
+    out.set_verbosity(verbose=False, quiet=False)
+
+
+def test_info_visible_by_default():
+    buf = _capture()
+    out.info("hello")
+    assert "hello" in buf.getvalue()
+
+
+def test_info_hidden_with_quiet():
+    out.set_verbosity(quiet=True)
+    buf = _capture()
+    out.info("hello")
+    assert buf.getvalue() == ""
+
+
+def test_verbose_info_hidden_by_default():
+    buf = _capture()
+    out.verbose_info("only-when-verbose")
+    assert "only-when-verbose" not in buf.getvalue()
+
+
+def test_verbose_info_visible_with_verbose():
+    out.set_verbosity(verbose=True)
+    buf = _capture()
+    out.verbose_info("only-when-verbose")
+    assert "only-when-verbose" in buf.getvalue()
+
+
+def test_error_visible_even_with_quiet():
+    """Errors must always print, even under --quiet."""
+    out.set_verbosity(quiet=True)
+    buf = _capture()
+    out.error("[red]boom[/red]")
+    assert "boom" in buf.getvalue()
+
+
+def test_verbose_overrides_quiet_when_both_set():
+    """--verbose wins over --quiet to keep the user's intent unambiguous."""
+    out.set_verbosity(verbose=True, quiet=True)
+    assert out.is_verbose()
+    assert not out.is_quiet()


### PR DESCRIPTION
## Summary

Two pre-launch quality-of-life improvements aimed at reducing the "this errored weirdly on first try" rate during the 24-hour Show HN window. No new features, no behavior changes for the happy path.

**Spec:** \`docs/specs/2026-04-30-polish.md\` (local).

## What changed

### 1. Connector error messages with actionable hints

\`BaseConnector\` gains a \`last_error: str | None\` property. Each \`connect()\` failure path sets a short hint instead of swallowing the exception. The CLI renders the hint right after the generic \`Failed to connect.\` header.

**Postgres** classifies:
- connection refused → "is the server reachable? Hint: \`docker compose ps\` / \`pg_isready\`"
- password authentication failed → "wrong username or password"
- database does not exist → "Hint: \`psql -l\`"
- SSL required → "Hint: append \`?sslmode=require\`"
- timeout / unknown host → matching hints
- unknown → first line of the raw error

**Snowflake** classifies:
- missing python package → "pip install scherlok[snowflake]"
- missing \`SNOWFLAKE_USER\` / \`SNOWFLAKE_PASSWORD\` → names the env var
- auth failure → "check creds; SSO/MFA needs key-pair auth"
- account / warehouse / database not found → matching hints

**BigQuery** classifies:
- missing google-cloud-bigquery → "pip install scherlok[bigquery]"
- ADC missing → "gcloud auth application-default login"
- permission denied → "grant roles/bigquery.dataViewer + roles/bigquery.jobUser"
- dataset / project not found, billing not enabled → matching hints

### 2. \`--verbose\` / \`--quiet\` global flags

New \`scherlok/output.py\` module: \`info()\` / \`verbose_info()\` / \`error()\`. Wired via Typer \`@app.callback()\` so flags work on every subcommand.

- \`--quiet\` / \`-q\` — silences progress chatter ("Profiling X...", "Watching N tables..."). Anomaly results, errors, and exit codes still surface. Idiomatic for CI logs.
- \`--verbose\` / \`-v\` — adds per-table timings ("orders: 1000 rows · 5 cols · 0.12s"), webhook/email delivery confirmations.
- Verbose wins over quiet when both are passed (preserves user intent unambiguously).
- \`scherlok dbt\`: ✓ rows respect \`--quiet\`; ✗ rows always print so CI logs surface failures even when silent.

### Item 3 (spinner) deferred

Originally in scope. After landing items 1 and 2, the per-table prints already provide visible progress; a spinner would conflict with them and only matter under \`--quiet\` (which by definition wants no output). Decision recorded in the spec doc.

## Test plan

- [x] \`ruff check src/ tests/\` — clean
- [x] \`pytest\` — 204 passing (17 new: 11 connector hints, 6 verbosity helpers)
- [x] Tests cover: ImportError paths for missing optional deps, env-var detection, error classification per adapter, verbose/quiet/error visibility rules
- [x] Manual: \`scherlok connect postgresql://wrong:pw@nowhere/db\` shows actionable hint
- [ ] CI green (waiting)

## Out of scope

Stdout vs stderr split (defer until someone complains). New features. Anything that changes the SQLite schema or detector contract.