### PR TITLE
chore: bump to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-- **`--verbose` / `-v` and `--quiet` / `-q` global flags** added to all commands. `--quiet` silences progress chatter while keeping anomaly results and errors (CI-friendly). `--verbose` adds per-table profiling timings and column counts.
-- **Connector error messages now include actionable hints.** `Failed to connect.` is followed by a one-line explanation of what went wrong, plus a hint when applicable.
-  - **Postgres:** classifies "connection refused" / "auth failed" / "database does not exist" / "SSL required" / timeout / unknown host
-  - **Snowflake:** detects missing `SNOWFLAKE_USER` / `SNOWFLAKE_PASSWORD`, missing python connector, auth failures, account/warehouse/database not found
-  - **BigQuery:** detects missing google-cloud-bigquery, missing Application Default Credentials, permission denied, project/dataset not found, billing not enabled
-
-### Added
-- **HTML dashboard** — new `scherlok dashboard` command. Generates a self-contained HTML report (~28 KB) from the local profile store: KPIs, per-table incidents grouped with summary/threshold/first-seen, schema-drift `+`/`-`/`~` diff, sparklines, and history. Auto dark/light theme via `prefers-color-scheme` (`--theme dark|light` to override). No external URLs in the rendered file — works offline, screenshot-friendly.
-  - Adds `jinja2>=3.0` to core dependencies
-  - New module: [`src/scherlok/dashboard/`](src/scherlok/dashboard/) (assembler, grouping, schema parser, template, render, CLI)
-  - Spec: [`docs/specs/2026-04-30-dashboard.md`](docs/specs/2026-04-30-dashboard.md)
-
-### Fixed
-- **Views were silently skipped** by `scherlok investigate`/`watch`/`dbt` on Postgres and Snowflake (`list_tables` filtered to `BASE TABLE` only). Materialized dbt views (`materialized: view`, the default for `staging/` models in layered dbt projects) are now discovered. ([#7](https://github.com/rbmuller/scherlok/issues/7))
+## [0.5.0] — 2026-04-30
 
 ### Added
 - **dbt integration v0** — new `scherlok dbt` command. Reads `target/manifest.json`, discovers materialized models (`table`/`incremental`/`view`/`materialized_view`), auto-resolves the connection from `profiles.yml` (postgres / bigquery / snowflake), and runs investigate + watch per model with dbt-style ✓/✗ output.
@@ -29,6 +15,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Flags: `--project-dir`, `--profiles-dir`, `--target`, `--connection-string`, `--select`, `--include-sources`, `--fail-on`, `--webhook`, `--email`
   - Supports `{{ env_var('NAME', 'default') }}` rendering in `profiles.yml`
   - Requires dbt 1.6+ (manifest schema v10+)
+- **HTML dashboard** — new `scherlok dashboard` command. Generates a self-contained HTML report (~28 KB) from the local profile store: KPIs, per-table incidents grouped with summary/threshold/first-seen, schema-drift `+`/`−`/`~` diff, sparklines, and history. Auto dark/light theme via `prefers-color-scheme` (`--theme dark|light` to override). Adds `jinja2>=3.0` to core dependencies.
+- **`examples/dbt_smoke/`** — runnable mini dbt project (3 models on top of the existing seeded Postgres in `examples/docker-compose.yml`) for contributors to reproduce the dbt + dashboard flow end-to-end.
+
+### Changed
+- **`--verbose` / `-v` and `--quiet` / `-q` global flags** added to all commands. `--quiet` silences progress chatter while keeping anomaly results and errors (CI-friendly). `--verbose` adds per-table profiling timings and column counts.
+- **Connector error messages now include actionable hints.** `Failed to connect.` is followed by a one-line explanation of what went wrong, plus a hint when applicable.
+  - **Postgres:** classifies "connection refused" / "auth failed" / "database does not exist" / "SSL required" / timeout / unknown host
+  - **Snowflake:** detects missing `SNOWFLAKE_USER` / `SNOWFLAKE_PASSWORD`, missing python connector, auth failures, account/warehouse/database not found
+  - **BigQuery:** detects missing google-cloud-bigquery, missing Application Default Credentials, permission denied, project/dataset not found, billing not enabled
+
+### Fixed
+- **Views were silently skipped** by `scherlok investigate`/`watch`/`dbt` on Postgres and Snowflake (`list_tables` filtered to `BASE TABLE` only). Materialized dbt views (`materialized: view`, the default for `staging/` models in layered dbt projects) are now discovered. ([#7](https://github.com/rbmuller/scherlok/issues/7))
+- **Release notes extraction in CI** — the awk in `release.yml` was using regex match against `## [version]`, where `[...]` is interpreted as a character class. Switched to literal-substring match so v0.5.0 release notes are properly extracted from `CHANGELOG.md` instead of falling back to the generic placeholder.
 
 ## [0.4.0] — 2026-04-27
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scherlok"
-version = "0.4.0"
+version = "0.5.0"
 description = "A detective for your data. Zero-config data quality monitoring."
 readme = "README.md"
 license = "MIT"

--- a/src/scherlok/__init__.py
+++ b/src/scherlok/__init__.py
@@ -1,3 +1,3 @@
 """Scherlok — A detective for your data. Zero-config data quality monitoring."""
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"


### PR DESCRIPTION
## Summary

Cuts v0.5.0. After this merges, tagging \`v0.5.0\` triggers \`.github/workflows/release.yml\` which runs tests, publishes to PyPI via trusted publishing, and creates the GitHub Release with auto-extracted notes.

## What's in v0.5.0

### Added
- **dbt integration v0** — \`scherlok dbt\` reads \`target/manifest.json\` and runs investigate + watch per model (Postgres / BigQuery / Snowflake). [#6](https://github.com/rbmuller/scherlok/pull/6)
- **HTML dashboard** — \`scherlok dashboard\` writes a self-contained 28 KB report with KPIs, per-table grouped incidents, schema-drift +/-/~ diff, sparklines. [#9](https://github.com/rbmuller/scherlok/pull/9)
- **\`examples/dbt_smoke/\`** — runnable mini dbt project for contributors. [#8](https://github.com/rbmuller/scherlok/pull/8)

### Changed
- **\`--verbose\` / \`--quiet\` global flags** (CI-friendly). [#10](https://github.com/rbmuller/scherlok/pull/10)
- **Connector error messages with actionable hints** (Postgres / Snowflake / BigQuery). [#10](https://github.com/rbmuller/scherlok/pull/10)

### Fixed
- **Views silently skipped on Postgres + Snowflake.** Default for dbt staging models. [#7 / #8](https://github.com/rbmuller/scherlok/issues/7)
- **Release notes extraction in CI** — awk regex bug where \`[0.5.0]\` was interpreted as character class. [#11](https://github.com/rbmuller/scherlok/pull/11)

## Files changed

- \`pyproject.toml\`: \`0.4.0\` → \`0.5.0\`
- \`src/scherlok/__init__.py\`: \`__version__\` bumped
- \`CHANGELOG.md\`: \`[Unreleased]\` block consolidated and renamed to \`[0.5.0] — 2026-04-30\`. Empty \`[Unreleased]\` placeholder kept above per Keep a Changelog convention.

## Validation

- [x] \`ruff check src/ tests/\` clean
- [x] \`pytest\` — 204 passing
- [x] Locally verified: \`awk -v ver="## [0.5.0]"\` extracts 22 lines from CHANGELOG.md
- [x] \`pip install -e .\` works locally on Python 3.14
- [ ] CI green (waiting)

## After merge

1. \`git tag v0.5.0 && git push origin v0.5.0\`
2. Release workflow runs (~50s typical) → PyPI publish + GitHub Release with full notes
3. Smoke-check the published \`scherlok==0.5.0\` package
4. Move on to launch artifacts (Opção 3): CONTRIBUTING.md, good-first-issues, blog draft, Show HN