### PR TITLE
docs: rewrite CONTRIBUTING.md for v0.5.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,52 +1,97 @@
 # Contributing to Scherlok
 
-Thanks for your interest in contributing to Scherlok!
+Thanks for considering a contribution. Scherlok is small, opinionated, and pragmatic — most changes can land in a weekend.
 
-## Development Setup
+## Ways to contribute
+
+- **Pick a [good first issue](https://github.com/rbmuller/scherlok/labels/good%20first%20issue)** — bite-sized tasks (1–2 hours) with clear acceptance criteria
+- **Add a new connector** — Postgres / BigQuery / Snowflake live in [`src/scherlok/connectors/`](src/scherlok/connectors/); each implements [`BaseConnector`](src/scherlok/connectors/base.py) (connect, list_tables, get_row_count, get_columns, get_column_stats, get_last_modified)
+- **Add a new detector** — [`src/scherlok/detector/`](src/scherlok/detector/) — a function that takes `(table, current_profile, stored_profile)` and returns anomaly dicts
+- **Improve docs** — module READMEs, examples, error messages
+- **Report bugs** — use the [bug template](https://github.com/rbmuller/scherlok/issues/new/choose); include the failing connection scheme + connector version
+
+## Development setup
 
 ```bash
-# Clone the repo
-git clone https://github.com/rbmuller/scherlok.git
+git clone https://github.com/rbmuller/scherlok
 cd scherlok
-
-# Create virtual environment
-python -m venv .venv
-source .venv/bin/activate
-
-# Install in development mode
-pip install -e ".[dev]"
-
-# Run tests
-pytest tests/ -v
-
-# Run linter
+python -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev]"      # base + tests + lint
+pip install -e ".[dbt]"      # if you'll touch dbt integration
 ruff check src/ tests/
+pytest                        # 200+ tests, runs in <1s
 ```
 
-## Code Standards
+To exercise the full flow end-to-end against a real Postgres + real dbt, see [`examples/dbt_smoke/`](examples/dbt_smoke/) — a runnable mini dbt project.
 
-- Python 3.10+ with type hints on all function signatures
-- Docstrings on all public functions
-- Use `pathlib` for file paths
-- Use `rich` for terminal output
-- Follow conventional commits for commit messages
+## Code style
 
-## Adding a New Connector
+- **Python 3.10+**, type hints on public APIs
+- **Ruff** for linting (config in `pyproject.toml`); CI fails on warnings
+- **Line length 100**
+- Prefer **explicit imports**; avoid wildcard
+- Use **`pathlib.Path`** over `os.path`
+- **String literals**: define constants for anything used twice (no magic strings)
+- **No new comments** unless they explain *why* something non-obvious is happening; well-named identifiers carry intent
 
-1. Create a new module in `src/scherlok/connectors/`
-2. Extend `BaseConnector` from `connectors/base.py`
-3. Register the scheme in `connectors/__init__.py`
-4. Add tests in `tests/test_connector.py`
+## Testing
 
-## Adding a New Alerter
+- All new code paths need tests. Aim for ≥1 happy-path test + ≥1 edge case
+- Use **mocks** for connectors that need cloud creds (see [`tests/test_bigquery.py`](tests/test_bigquery.py), [`tests/test_snowflake.py`](tests/test_snowflake.py))
+- Use **fixtures** for shared test data (see [`tests/fixtures/dbt/`](tests/fixtures/dbt/))
+- Snapshot tests for the dashboard guard against accidental UI regressions
 
-1. Create a new module in `src/scherlok/alerter/`
-2. Follow the pattern from `alerter/slack.py` or `alerter/console.py`
-3. Add tests
+## Commit format
 
-## Pull Requests
+[Conventional Commits](https://www.conventionalcommits.org/) lite — Scherlok uses these prefixes:
 
-- Create a branch from `main`
-- Write tests for new functionality
-- Make sure `pytest` and `ruff check` pass
-- Open a PR with a clear description
+- `feat:` — user-visible new functionality
+- `fix:` — bug fix
+- `chore:` — non-user-facing maintenance (build, deps, refactor, release prep)
+- `docs:` — docs/comments only
+- `test:` — test-only changes
+
+Subject line ≤72 chars. Body explains the *why*, not the *what*. Multi-line is fine.
+
+## Pull request flow
+
+1. **Branch** from `main` — `feat/<short-description>` or `fix/<short-description>`
+2. **One PR per logical change.** Don't bundle a feature with unrelated cleanup
+3. **Run `ruff check src/ tests/` and `pytest` locally** before pushing — CI mirrors these
+4. **Open the PR with a body that covers**: what changed, why, how to test, screenshots if UI
+5. **Wait for review** — single approval required to merge
+6. **Squash merge** is the default
+
+## Adding a new connector
+
+The fastest path is to read [`postgres.py`](src/scherlok/connectors/postgres.py) and clone its shape. Then:
+
+1. Create `src/scherlok/connectors/<name>.py` extending `BaseConnector`
+2. Register the scheme(s) in [`src/scherlok/connectors/__init__.py`](src/scherlok/connectors/__init__.py); wrap the import in `try/except ImportError` if the driver is heavy
+3. Add the optional dependency in `pyproject.toml` under `[project.optional-dependencies]`
+4. Add tests in `tests/test_<name>.py` using mocks (see existing connector tests)
+5. Document in the README's "Supported adapters" section
+
+If your warehouse is one users wire up via dbt, add the adapter mapping in [`src/scherlok/dbt/profiles.py`](src/scherlok/dbt/profiles.py) too.
+
+## Adding a new alerter
+
+[`src/scherlok/alerter/`](src/scherlok/alerter/) hosts webhook + email today. To add another channel:
+
+1. Create `src/scherlok/alerter/<name>.py` with a `send_<name>(target, anomalies)` function
+2. Wire it into the dispatch path in [`src/scherlok/cli.py`](src/scherlok/cli.py) (look for `_dispatch_alerts`)
+3. Add tests with mocked HTTP / SMTP
+
+## Release process
+
+For maintainers only:
+
+1. Bump `version` in `pyproject.toml` and `__version__` in `src/scherlok/__init__.py`
+2. Move `[Unreleased]` to `[X.Y.Z] — YYYY-MM-DD` in `CHANGELOG.md`
+3. PR + merge to main
+4. `git tag vX.Y.Z && git push origin vX.Y.Z`
+5. `.github/workflows/release.yml` runs tests, publishes to PyPI via trusted publishing, creates GitHub Release with auto-extracted notes
+
+## Code of conduct
+
+Be helpful. Assume good faith. Disagree on technical merits, not on people. Threads should leave both sides smarter than they entered.


### PR DESCRIPTION
## Summary

The previous CONTRIBUTING was a 53-line stub written before the recent feature waves. It was outdated:

- No mention of the \`[dbt]\` extra or the dbt integration module
- No mention of the dashboard module or snapshot tests
- Pointed contributors at \`alerter/slack.py\` as an example — that file was deleted in v0.3.0 when the generic webhook replaced it
- Didn't cover the conventional-commits + branch+PR flow this repo actually uses

## What's in the rewrite

- **Ways to contribute** — good-first-issues, new connectors, new detectors, docs, bug reports
- **Development setup** — clone, venv, \`[dev]\` + optional \`[dbt]\` extra, ruff + pytest commands
- **Code style** — Python 3.10+, ruff, line length, no comments-as-narration policy
- **Testing** — happy + edge case requirement, mocks for cloud connectors, fixtures, dashboard snapshot tests
- **Commit format** — conventional commits lite (feat/fix/chore/docs/test)
- **Pull request flow** — branching, single-PR-per-change, ruff+pytest pre-push, single-approval squash-merge
- **Adding a new connector** — concrete 5-step recipe pointing at \`postgres.py\` as the template + dbt mapping
- **Adding a new alerter** — short recipe (replaces the broken slack.py reference)
- **Release process** — for maintainers; documents the bump → tag → workflow flow we just exercised in v0.5.0
- **Code of conduct** — one paragraph

## Why now

Lands the same week as the 10 seed good-first-issues batch (drafts in local \`docs/launch/2026-04-30-good-first-issues.md\`). New contributors clicking through from those issues should find a clean, accurate onboarding doc.

## Test plan

- [x] No code changes; \`pytest\` still 204 passing locally
- [x] \`ruff check\` clean
- [x] All file links in the doc resolve to files that exist on \`main\`
- [ ] CI green (waiting)