### PR TITLE
feat: add --include-snapshots flag to scherlok dbt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`scherlok dbt --include-snapshots`** — opt-in flag to also profile dbt snapshot nodes. Snapshots are SCD Type 2 tables that physically exist in the warehouse and are profilable like any other materialized model; they were skipped in v0 because `discover_models` filtered to `resource_type == "model"`. When the flag is unset, behavior is unchanged. ([#22](https://github.com/rbmuller/scherlok/issues/22))
+
 ## [0.5.0] — 2026-04-30
 
 ### Added

--- a/src/scherlok/cli.py
+++ b/src/scherlok/cli.py
@@ -411,6 +411,12 @@ def dbt(
     include_sources: bool = typer.Option(
         False, "--include-sources", help="Also profile dbt sources, not only models"
     ),
+    include_snapshots: bool = typer.Option(
+        False,
+        "--include-snapshots",
+        help="Also profile dbt snapshots. Snapshots are SCD Type 2 tables that exist "
+        "in the warehouse and are profilable like regular materialized models.",
+    ),
     webhook: str = typer.Option(
         None, "--webhook", "-w", help="Webhook URL for alerts"
     ),
@@ -449,7 +455,7 @@ def dbt(
         raise typer.Exit(code=1) from exc
 
     adapter = manifest.get("metadata", {}).get("adapter_type", "?")
-    nodes: list[DbtNode] = discover_models(manifest)
+    nodes: list[DbtNode] = discover_models(manifest, include_snapshots=include_snapshots)
     if include_sources:
         nodes.extend(discover_sources(manifest))
 

--- a/src/scherlok/dbt/manifest.py
+++ b/src/scherlok/dbt/manifest.py
@@ -66,17 +66,34 @@ def load_manifest(project_dir: str | Path) -> dict:
     return manifest
 
 
-def discover_models(manifest: dict) -> list[DbtNode]:
-    """Return all materialized models (table/incremental/view) from the manifest."""
+def discover_models(manifest: dict, include_snapshots: bool = False) -> list[DbtNode]:
+    """Return all materialized models (table/incremental/view) from the manifest.
+
+    Args:
+        manifest: Loaded manifest.json dict.
+        include_snapshots: When True, also include snapshot nodes. Snapshots are
+            SCD Type 2 tables that physically exist in the warehouse and are
+            profilable like any other materialized model. Defaults to False to
+            preserve the v0 behavior of skipping snapshots.
+    """
     adapter = manifest.get("metadata", {}).get("adapter_type", "")
     nodes = manifest.get("nodes", {})
     models: list[DbtNode] = []
 
     for unique_id, node in nodes.items():
-        if node.get("resource_type") != "model":
-            continue
+        resource_type = node.get("resource_type")
         materialized = node.get("config", {}).get("materialized", "")
-        if materialized not in MATERIALIZED_PHYSICAL:
+
+        if resource_type == "model":
+            if materialized not in MATERIALIZED_PHYSICAL:
+                continue
+        elif resource_type == "snapshot" and include_snapshots:
+            # dbt snapshots set config.materialized to "snapshot". The underlying
+            # physical relation is a table, so they are profilable like any other
+            # materialized model. We preserve the original value so callers can
+            # distinguish snapshots from regular models via DbtNode.materialized.
+            pass
+        else:
             continue
 
         identifier = node.get("alias") or node.get("name", "")
@@ -84,7 +101,7 @@ def discover_models(manifest: dict) -> list[DbtNode]:
             DbtNode(
                 unique_id=unique_id,
                 name=node.get("name", ""),
-                resource_type="model",
+                resource_type=resource_type,
                 materialized=materialized,
                 database=node.get("database", "") or "",
                 schema=node.get("schema", "") or "",

--- a/tests/test_dbt_manifest.py
+++ b/tests/test_dbt_manifest.py
@@ -96,3 +96,65 @@ def test_load_manifest_unsupported_adapter(tmp_path):
     )
     with pytest.raises(ValueError, match="Unsupported dbt adapter 'redshift'"):
         load_manifest(tmp_path)
+
+
+def _manifest_with_snapshot() -> dict:
+    """Build a minimal manifest containing one model and one snapshot."""
+    return {
+        "metadata": {
+            "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
+            "adapter_type": "postgres",
+        },
+        "nodes": {
+            "model.demo.fct_orders": {
+                "resource_type": "model",
+                "name": "fct_orders",
+                "alias": "fct_orders",
+                "database": "demo_db",
+                "schema": "public",
+                "relation_name": '"demo_db"."public"."fct_orders"',
+                "config": {"materialized": "table"},
+            },
+            "snapshot.demo.orders_snapshot": {
+                "resource_type": "snapshot",
+                "name": "orders_snapshot",
+                "alias": "orders_snapshot",
+                "database": "demo_db",
+                "schema": "snapshots",
+                "relation_name": '"demo_db"."snapshots"."orders_snapshot"',
+                "config": {"materialized": "snapshot"},
+            },
+        },
+        "sources": {},
+    }
+
+
+def test_discover_models_skips_snapshots_by_default():
+    manifest = _manifest_with_snapshot()
+    models = discover_models(manifest)
+    names = {m.name for m in models}
+    assert "fct_orders" in names
+    assert "orders_snapshot" not in names
+
+
+def test_discover_models_include_snapshots_picks_up_snapshot_nodes():
+    manifest = _manifest_with_snapshot()
+    models = discover_models(manifest, include_snapshots=True)
+    names = {m.name for m in models}
+    assert names == {"fct_orders", "orders_snapshot"}
+
+    snap = next(m for m in models if m.name == "orders_snapshot")
+    assert snap.resource_type == "snapshot"
+    assert snap.materialized == "snapshot"
+    assert snap.database == "demo_db"
+    assert snap.schema == "snapshots"
+    assert snap.identifier == "orders_snapshot"
+    assert snap.adapter == "postgres"
+
+
+def test_discover_models_include_snapshots_no_op_when_no_snapshots():
+    """include_snapshots=True does not change behavior when no snapshots exist."""
+    manifest = load_manifest(PG_PROJECT)
+    default = discover_models(manifest)
+    expanded = discover_models(manifest, include_snapshots=True)
+    assert {m.unique_id for m in default} == {m.unique_id for m in expanded}


### PR DESCRIPTION
## Summary

Adds an opt-in `--include-snapshots` flag to `scherlok dbt` so dbt snapshots can be profiled alongside materialized models.

Closes #22.

## Why this matters

`discover_models()` in `src/scherlok/dbt/manifest.py` filtered to `resource_type == "model"` plus the four `MATERIALIZED_PHYSICAL` config values, so dbt snapshot nodes (`resource_type == "snapshot"`, `config.materialized == "snapshot"`) were silently dropped. The issue body called this out directly: "Snapshots are tables that exist in the warehouse and are perfectly profilable - adding them is a 1-flag change." Same shape as the `--include-sources` flag that already exists on `scherlok dbt` for the parallel sources case.

## Changes

- `src/scherlok/dbt/manifest.py`: `discover_models()` now takes `include_snapshots: bool = False`. When True, it also yields `DbtNode`s for `resource_type == "snapshot"` (preserving `config.materialized` so callers can tell snapshots from regular models). The model branch keeps the `MATERIALIZED_PHYSICAL` filter; the snapshot branch is unconditional within `include_snapshots=True` because dbt always materializes snapshots as physical tables.
- `src/scherlok/cli.py`: New `--include-snapshots` flag on `scherlok dbt`, threaded into the `discover_models()` call. Help text matches the tone of `--include-sources`.

## Testing

`pytest` — 210 passed (the 3 new tests in `tests/test_dbt_manifest.py` cover the three documented states):

- `test_discover_models_skips_snapshots_by_default` — flag unset, snapshot node is dropped.
- `test_discover_models_include_snapshots_picks_up_snapshot_nodes` — flag set, snapshot node is yielded with `resource_type="snapshot"` and `materialized="snapshot"`.
- `test_discover_models_include_snapshots_no_op_when_no_snapshots` — flag set, no snapshots in fixture, output identical to default call (regression guard against accidentally widening the model filter).

`ruff check src/ tests/` — clean.

The tests use an inline manifest dict rather than mutating the existing `jaffle_shop_postgres` fixture so the existing fixture-based tests stay unchanged. Happy to add a snapshot to the fixture instead if you'd prefer end-to-end coverage; let me know.

## Notes for reviewer

- I left existing model behavior bit-identical: `MATERIALIZED_PHYSICAL` still gates models, and `include_snapshots` is opt-in (default False).
- `DbtNode.materialized` for a snapshot is `"snapshot"`, not coerced to `"table"` — that surfaces the kind to downstream callers without committing them to a particular interpretation.
- CHANGELOG entry under `[Unreleased]` -> `Added`.
