### PR TITLE
chore: dbt snapshots follow-up — header label + module README

### DIFF
--- a/src/scherlok/cli.py
+++ b/src/scherlok/cli.py
@@ -502,8 +502,9 @@ def dbt(
         else:
             matched.append((node, physical))
 
+    node_label = "nodes" if (include_sources or include_snapshots) else "models"
     out_info(
-        f"Investigating [bold]{len(matched)}[/bold] dbt {'nodes' if include_sources else 'models'} "
+        f"Investigating [bold]{len(matched)}[/bold] dbt {node_label} "
         f"in [cyan]{project_dir}[/cyan] ([dim]{adapter}[/dim])"
     )
     if missing:

--- a/src/scherlok/dbt/README.md
+++ b/src/scherlok/dbt/README.md
@@ -28,7 +28,7 @@ First run = baseline. Subsequent runs detect drift.
 ## How it discovers what to profile
 
 - **Materialized models only.** Models with `materialized: ephemeral` are skipped (they don't exist in the warehouse).
-- **Tests / seeds / snapshots are skipped** in v0 — only `resource_type: model` (and optionally `source` with `--include-sources`) are profiled.
+- **Tests and seeds are skipped** — only `resource_type: model` (and optionally `source` via `--include-sources`, `snapshot` via `--include-snapshots`) are profiled.
 - **Filtering:** `--select fct_orders --select stg_orders` profiles only the listed models.
 
 ## Supported adapters
@@ -86,6 +86,5 @@ Add Scherlok as a gate after `dbt run`:
 - No support for ephemeral models (they're not materialized — nothing to profile).
 - No support for adapter-specific Jinja in `profiles.yml` beyond `env_var`.
 - Lineage is **not yet** read from the manifest — anomalies are reported per-model with no downstream impact.
-- Snapshots are not profiled in v0.
 
 If you hit one of these, please open an issue.


### PR DESCRIPTION
## Summary

Two small follow-ups I called out in the [#26 review](https://github.com/rbmuller/scherlok/pull/26#pullrequestreview) — clearing them in a sweep so the docs match the new flag.

### 1. CLI header label

\`scherlok dbt --include-snapshots\` (without \`--include-sources\`) was printing:

> Investigating 4 dbt **models** in ...

even though the count includes snapshots. Now the label switches to **nodes** when *either* flag is set:

\`\`\`python
node_label = \"nodes\" if (include_sources or include_snapshots) else \"models\"
\`\`\`

### 2. \`src/scherlok/dbt/README.md\`

Two stale lines from before #26 landed:

- The \"How it discovers what to profile\" section read *\"Tests / seeds / snapshots are skipped\"*. Updated to document \`--include-snapshots\` alongside the existing \`--include-sources\`.
- The \"Limitations of v0\" section still listed *\"Snapshots are not profiled in v0\"*. Bullet removed.

## Test plan

- [x] \`ruff check src/ tests/\` clean
- [x] \`pytest\` — 210 passing (unchanged)
- [x] No code-path changes; only header text + doc bullets
- [ ] CI green (waiting)