### PR TITLE
feat(dashboard): add 14-day anomaly trend barchart

### DIFF
--- a/src/scherlok/dashboard/assembler.py
+++ b/src/scherlok/dashboard/assembler.py
@@ -154,7 +154,11 @@ def _anomaly_trend(anomalies: list[dict], days: int) -> list[dict]:
         )
 
     trend = []
-    for offset in range(days - 1, -1, -1):
+    # Emit days+1 bars so the cutoff date itself is included. ProfileStore's
+    # `get_anomaly_history(days=N)` uses a `now() - N days` SQL cutoff, so an
+    # anomaly with `detected_at == today - N` is part of the window. Without
+    # this extra bar the chart silently dropped that day's anomalies.
+    for offset in range(days, -1, -1):
         day = today - timedelta(days=offset)
         date_key = day.isoformat()
         severities = buckets.get(date_key, [])

--- a/src/scherlok/dashboard/assembler.py
+++ b/src/scherlok/dashboard/assembler.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from scherlok import __version__
 from scherlok.dashboard.grouping import Incident, group_anomalies
@@ -42,6 +42,7 @@ def assemble_view(
         "meta": meta,
         "kpis": kpis,
         "dbt_context": dbt_context,
+        "trend": _anomaly_trend(anomalies, days),
         "incidents": incidents,
         "tables": tables,
         "history": history,
@@ -129,6 +130,52 @@ def _sparkline_path(points: list[int], status: str) -> str:
         y = 18 - ((v - lo) / span) * 16
         coords.append(f"{x:.1f},{y:.1f}")
     return "M" + " L".join(coords)
+
+
+def _anomaly_trend(anomalies: list[dict], days: int) -> list[dict]:
+    """Return daily anomaly counts oldest -> newest for the dashboard chart."""
+    if days <= 0:
+        return []
+
+    today = datetime.now(timezone.utc).date()
+    buckets: dict[str, list[str]] = {}
+    for anomaly in anomalies:
+        detected_at = anomaly.get("detected_at")
+        if not detected_at:
+            continue
+        try:
+            detected_date = datetime.fromisoformat(
+                detected_at.replace("Z", "+00:00")
+            ).date()
+        except ValueError:
+            continue
+        buckets.setdefault(detected_date.isoformat(), []).append(
+            _severity_value(anomaly.get("severity"))
+        )
+
+    trend = []
+    for offset in range(days - 1, -1, -1):
+        day = today - timedelta(days=offset)
+        date_key = day.isoformat()
+        severities = buckets.get(date_key, [])
+        trend.append({
+            "date": date_key,
+            "count": len(severities),
+            "severity": _max_daily_severity(severities),
+        })
+    return trend
+
+
+def _severity_value(severity: object) -> str:
+    return str(getattr(severity, "value", severity or "")).upper()
+
+
+def _max_daily_severity(severities: list[str]) -> str:
+    if "CRITICAL" in severities:
+        return "critical"
+    if "WARNING" in severities:
+        return "warning"
+    return "healthy"
 
 
 def _kpis(tables: list[dict], incidents: list[Incident], days: int) -> dict:

--- a/src/scherlok/dashboard/assembler.py
+++ b/src/scherlok/dashboard/assembler.py
@@ -175,6 +175,8 @@ def _max_daily_severity(severities: list[str]) -> str:
         return "critical"
     if "WARNING" in severities:
         return "warning"
+    if "INFO" in severities:
+        return "info"
     return "healthy"
 
 

--- a/src/scherlok/dashboard/styles.css
+++ b/src/scherlok/dashboard/styles.css
@@ -88,6 +88,18 @@ section h2 {
   color: var(--muted); margin-bottom: 10px; font-weight: 600;
 }
 
+/* Anomaly trend */
+.trend-svg {
+  display: block; width: 100%; height: 60px;
+  background: var(--panel); border: 1px solid var(--line); border-radius: 8px;
+  padding: 6px 0; box-shadow: var(--shadow);
+}
+.trend-bar { shape-rendering: crispEdges; }
+.trend-bar.critical { fill: var(--red); }
+.trend-bar.warning { fill: var(--yellow); }
+.trend-bar.healthy { fill: var(--green); opacity: 0.18; }
+.trend .empty { padding: 18px; font-size: 13px; color: var(--muted); }
+
 /* Incident cards */
 .incident {
   background: var(--panel); border: 1px solid var(--line);

--- a/src/scherlok/dashboard/styles.css
+++ b/src/scherlok/dashboard/styles.css
@@ -97,6 +97,7 @@ section h2 {
 .trend-bar { shape-rendering: crispEdges; }
 .trend-bar.critical { fill: var(--red); }
 .trend-bar.warning { fill: var(--yellow); }
+.trend-bar.info { fill: var(--muted); opacity: 0.4; }
 .trend-bar.healthy { fill: var(--green); opacity: 0.18; }
 .trend .empty { padding: 18px; font-size: 13px; color: var(--muted); }
 

--- a/src/scherlok/dashboard/template.html
+++ b/src/scherlok/dashboard/template.html
@@ -50,6 +50,27 @@
     </div>
   </div>
 
+  {% if trend %}
+  <section class="trend">
+    <h2>Anomaly trend · last {{ kpis.history_days }} days</h2>
+    {% if trend | sum(attribute='count') == 0 %}
+    <div class="empty">No anomalies in this window.</div>
+    {% else %}
+    <svg class="trend-svg" viewBox="0 0 {{ trend | length * 14 }} 60" width="100%" height="60" preserveAspectRatio="none">
+      {% set max_count = trend | map(attribute='count') | max %}
+      {% for day in trend %}
+      <rect class="trend-bar {{ day.severity }}"
+            x="{{ loop.index0 * 14 + 2 }}" y="{{ 50 - (day.count / max_count * 48) if max_count else 50 }}"
+            width="10" height="{{ (day.count / max_count * 48) if max_count else 0 }}"
+            rx="1">
+        <title>{{ day.date }}: {{ day.count }} anomalies</title>
+      </rect>
+      {% endfor %}
+    </svg>
+    {% endif %}
+  </section>
+  {% endif %}
+
   {% if dbt_context %}
   <section>
     <h2>dbt context</h2>

--- a/tests/test_dashboard_render.py
+++ b/tests/test_dashboard_render.py
@@ -90,7 +90,8 @@ def test_render_anomaly_trend_renders(tmp_path: Path):
 
     assert 'class="trend"' in html
     assert 'class="trend-svg"' in html
-    assert html.count('class="trend-bar') == 14
+    # default 14-day window emits 15 bars (cutoff date inclusive)
+    assert html.count('class="trend-bar') == 15
     assert 'class="trend-bar critical"' in html
     assert 'class="trend-bar warning"' in html
     assert 'class="trend-bar info"' in html

--- a/tests/test_dashboard_render.py
+++ b/tests/test_dashboard_render.py
@@ -67,6 +67,7 @@ def test_render_anomaly_trend_renders(tmp_path: Path):
             (0, Severity.WARNING),
             (2, Severity.CRITICAL),
             (5, Severity.WARNING),
+            (7, Severity.INFO),
         ]:
             store.save_anomalies([
                 {
@@ -92,6 +93,7 @@ def test_render_anomaly_trend_renders(tmp_path: Path):
     assert html.count('class="trend-bar') == 14
     assert 'class="trend-bar critical"' in html
     assert 'class="trend-bar warning"' in html
+    assert 'class="trend-bar info"' in html
 
 
 def test_render_redacts_password(store_with_data):

--- a/tests/test_dashboard_render.py
+++ b/tests/test_dashboard_render.py
@@ -1,5 +1,6 @@
 """End-to-end render tests + golden HTML snapshot for dashboard regressions."""
 
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -57,6 +58,40 @@ def test_render_dbt_context_omitted_when_none(store_with_data):
     """The dbt-card div only renders when dbt_context is provided."""
     html = render_dashboard(store_with_data, dbt_context=None)
     assert "<div class=\"dbt-card\">" not in html
+
+
+def test_render_anomaly_trend_renders(tmp_path: Path):
+    store = ProfileStore(db_path=tmp_path / "profiles.db")
+    try:
+        for days_ago, severity in [
+            (0, Severity.WARNING),
+            (2, Severity.CRITICAL),
+            (5, Severity.WARNING),
+        ]:
+            store.save_anomalies([
+                {
+                    "table": "orders",
+                    "type": "volume_drop",
+                    "severity": severity,
+                    "message": f"Anomaly from {days_ago} days ago",
+                },
+            ])
+            detected_at = (datetime.now(timezone.utc) - timedelta(days=days_ago)).isoformat()
+            store._conn.execute(  # noqa: SLF001
+                "UPDATE anomalies SET detected_at = ? WHERE id = (SELECT MAX(id) FROM anomalies)",
+                (detected_at,),
+            )
+            store._conn.commit()  # noqa: SLF001
+
+        html = render_dashboard(store)
+    finally:
+        store.close()
+
+    assert 'class="trend"' in html
+    assert 'class="trend-svg"' in html
+    assert html.count('class="trend-bar') == 14
+    assert 'class="trend-bar critical"' in html
+    assert 'class="trend-bar warning"' in html
 
 
 def test_render_redacts_password(store_with_data):


### PR DESCRIPTION
## Summary

Resolves #20. Adds an "Anomaly trend" SVG barchart between the KPIs and the active-incident list. One bar per day in the history window, colored by max severity that day (`critical`/`warning`/`info`/`healthy`). The dashboard already had a sparkline-style chart for per-table volume — this is the cross-cutting "is data quality getting better or worse?" view the issue called out.

## Why this matters

The dashboard could already tell you *how many* incidents are active right now, but you couldn't see whether things are trending up or down without scrolling through `Recent anomaly history`. A 14-bar SVG (one rect per day) lives natively in the existing `template.html` flow with no new dependency.

I built the trend in `assembler.py` next to `_sparkline_path` (line 118 of `main`) so the data-shaping pattern matches the existing per-table sparkline — `_anomaly_trend(anomalies, days)` returns `[{date, count, severity}]` oldest -> newest, and `_max_daily_severity(severities)` collapses each day's anomaly severities into a single bar color. Severity bucketing matches the `Severity` enum in `src/scherlok/detector/severity.py` (`CRITICAL` > `WARNING` > `INFO`).

## Changes

- `assembler.py`: new `_anomaly_trend` helper + `_severity_value` / `_max_daily_severity` shape-matching helpers; threaded into the view-model dict.
- `template.html`: new `<section class="trend">` block between `.kpis` and `dbt_context`, with an empty-state path when the window has zero anomalies.
- `styles.css`: `.trend-svg` + `.trend-bar.{critical,warning,info,healthy}` colors using the existing palette tokens.
- `test_dashboard_render.py`: regression test seeds anomalies on three different days (CRITICAL / WARNING / INFO) plus an empty day and asserts the SVG renders with the expected severity classes.

The trend window emits `days + 1` bars so the SQL cutoff date itself is included — `get_anomaly_history(days=N)` uses a `now() - N days` cutoff, which can return anomalies whose calendar date equals `today - N`. Without that extra bar the chart would silently drop the boundary day.

## Testing

- `uv run pytest tests/test_dashboard_render.py` — 10/10 pass.
- `uv run pytest` (full suite) — 211/211 pass.
- `uv run ruff check src tests` — clean.

Fixes #20
