### PR TITLE
feat(dashboard): add stale tables panel

### DIFF
--- a/src/scherlok/dashboard/assembler.py
+++ b/src/scherlok/dashboard/assembler.py
@@ -10,6 +10,7 @@ from scherlok.store.sqlite import ProfileStore
 
 SPARKLINE_POINTS = 8
 DEFAULT_HISTORY_DAYS = 14
+STALE_TABLE_THRESHOLD_HOURS = 24
 
 
 def assemble_view(
@@ -29,6 +30,7 @@ def assemble_view(
     incidents = group_anomalies(active)
 
     tables = _build_table_health(store, days, incidents)
+    stale_tables = _build_stale_tables(store, days, tables)
 
     kpis = _kpis(tables, incidents, days)
     meta = _meta(
@@ -45,6 +47,7 @@ def assemble_view(
         "trend": _anomaly_trend(anomalies, days),
         "incidents": incidents,
         "tables": tables,
+        "stale_tables": stale_tables,
         "history": history,
     }
 
@@ -90,10 +93,47 @@ def _build_table_health(
             "rows": vol.get("row_count", 0),
             "cols": len(sch.get("columns", [])) if sch else 0,
             "last_profiled": _humanize_iso(vol.get("timestamp")),
+            "last_profiled_iso": vol.get("timestamp"),
             "sparkline_path": _sparkline_path(history_pts, status),
             "trend_points": history_pts,
         })
     return out
+
+
+def _build_stale_tables(
+    store: ProfileStore,
+    days: int,
+    tables: list[dict],
+) -> list[dict]:
+    """Return tables whose latest volume profile is older than the freshness threshold."""
+    del store, days
+
+    now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(hours=STALE_TABLE_THRESHOLD_HOURS)
+    stale_tables = []
+
+    for table in tables:
+        last_profiled_iso = table.get("last_profiled_iso")
+        if not last_profiled_iso:
+            continue
+
+        try:
+            last_profiled = datetime.fromisoformat(last_profiled_iso.replace("Z", "+00:00"))
+        except ValueError:
+            continue
+
+        if last_profiled.tzinfo is None:
+            last_profiled = last_profiled.replace(tzinfo=timezone.utc)
+
+        if last_profiled <= cutoff:
+            age_hours = (now - last_profiled).total_seconds() / 3600
+            stale_tables.append({
+                "name": table["name"],
+                "last_profiled": table["last_profiled"],
+                "age_hours": age_hours,
+            })
+
+    return sorted(stale_tables, key=lambda table: table["age_hours"], reverse=True)
 
 
 def _discover_tables(store: ProfileStore) -> set[str]:

--- a/src/scherlok/dashboard/template.html
+++ b/src/scherlok/dashboard/template.html
@@ -187,6 +187,33 @@
   </section>
   {% endif %}
 
+  {% if stale_tables %}
+  <section>
+    <h2>Stale tables · {{ stale_tables | length }}</h2>
+    <p class="muted">Tables whose last profile is older than the freshness threshold; check for silent ETL failures.</p>
+    <div class="grid">
+      <table>
+        <thead>
+          <tr>
+            <th>Table</th>
+            <th>Last profiled</th>
+            <th class="num">Age</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for t in stale_tables %}
+          <tr>
+            <td class="name">{{ t.name }}</td>
+            <td class="muted">{{ t.last_profiled }}</td>
+            <td class="num">{{ '%.1f' % t.age_hours }}h</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+  {% endif %}
+
   {% if history %}
   <section>
     <h2>Recent anomaly history ({{ kpis.history_days }} days)</h2>

--- a/tests/test_dashboard_assembler.py
+++ b/tests/test_dashboard_assembler.py
@@ -21,8 +21,13 @@ def store(tmp_path: Path):
     s.close()
 
 
-def _seed_profile(store: ProfileStore, table: str, rows: int):
-    store.save_profile(table, "volume", {"row_count": rows, "timestamp": "2026-04-30T12:00:00Z"})
+def _seed_profile(
+    store: ProfileStore,
+    table: str,
+    rows: int,
+    timestamp: str = "2026-04-30T12:00:00Z",
+):
+    store.save_profile(table, "volume", {"row_count": rows, "timestamp": timestamp})
     store.save_profile(table, "schema", {"columns": [{"name": "id", "type": "int"}]})
     store.save_profile(table, "freshness", {})
 
@@ -43,6 +48,27 @@ def test_assemble_with_profiles_no_anomalies(store):
     assert view["kpis"]["critical"] == 0
     assert view["kpis"]["warnings"] == 0
     assert {t["name"] for t in view["tables"]} == {"orders", "users"}
+
+
+def test_assemble_stale_tables_lists_only_tables_over_threshold(store):
+    now = datetime.now(timezone.utc)
+    _seed_profile(store, "fresh_orders", 1000, (now - timedelta(hours=1)).isoformat())
+    _seed_profile(store, "stale_orders", 900, (now - timedelta(hours=48)).isoformat())
+
+    view = assemble_view(store)
+
+    assert [table["name"] for table in view["stale_tables"]] == ["stale_orders"]
+    assert view["stale_tables"][0]["age_hours"] >= 48
+
+
+def test_assemble_stale_tables_empty_when_all_tables_are_fresh(store):
+    now = datetime.now(timezone.utc)
+    _seed_profile(store, "orders", 1000, (now - timedelta(hours=1)).isoformat())
+    _seed_profile(store, "users", 500, (now - timedelta(hours=2)).isoformat())
+
+    view = assemble_view(store)
+
+    assert view["stale_tables"] == []
 
 
 def test_assemble_active_anomalies_split_from_history(store):


### PR DESCRIPTION
## What changed

Adds a "Stale tables" dashboard panel between Table health and Recent anomaly history. Tables whose latest volume profile is older than `STALE_TABLE_THRESHOLD_HOURS` (default 24h) get listed with their last-profiled human string and an age in hours.

Closes #21

- `src/scherlok/dashboard/assembler.py`: new `STALE_TABLE_THRESHOLD_HOURS = 24` module constant. `_build_table_health` now also returns the raw `last_profiled_iso` so `_build_stale_tables` can compare against `datetime.now(timezone.utc)` without re-querying the store. `assemble_view` adds a `stale_tables` key to the view-model.
- `src/scherlok/dashboard/template.html`: new `<section>` rendered only when `stale_tables` is non-empty (the issue asked for the empty-state to be omitted entirely). Same `<div class="grid">` + `<table>` shell as the surrounding sections.
- `tests/test_dashboard_assembler.py`: extends `_seed_profile` with an optional `timestamp` kwarg so the fresh/stale split is testable, then adds two tests — one seeding `fresh_orders` (1h old) and `stale_orders` (48h old) and asserting only the stale one is in `view["stale_tables"]`, and one verifying the panel is empty (`[]`) when every table is fresh.

## Why

A table that was last profiled 5 days ago when the freshness window expects 6h refreshes is a silent ETL failure — exactly the case the issue calls out. Surfacing it as a dedicated panel between table-health and history puts it where someone scanning the report top-to-bottom would actually see it, rather than hiding it inside the existing table-health rows where it might be filtered to "healthy" by status.

The threshold is a module constant (not yet wired to the freshness window per-table) — keeping this PR focused on the panel surface, since per-table freshness windows live in a separate config file. Happy to follow up with config wiring if you'd like that as a separate PR.

## Verification

- `uv run pytest tests/test_dashboard_assembler.py -x -q` — 12/12 passes.
- `uv run ruff check src tests` — clean.
