### PR TITLE
feat: add multi-stage Dockerfile + ghcr publish workflow (#35)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,64 @@
+name: Docker
+
+# Builds the scherlok container image and publishes it to GitHub Container
+# Registry (ghcr.io/rbmuller/scherlok) on every release tag, mirroring the
+# trigger of release.yml so PyPI and GHCR ship together.
+#
+# Per-PR / per-push validation lives in ci.yml. This workflow is gated on
+# tags so non-release branches do not block on a Docker build.
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write  # push to ghcr.io
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve image tags
+        id: tags
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#v}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/rbmuller/scherlok:${{ steps.tags.outputs.version }}
+            ghcr.io/rbmuller/scherlok:latest
+          labels: |
+            org.opencontainers.image.source=https://github.com/rbmuller/scherlok
+            org.opencontainers.image.description=Scherlok data anomaly detection CLI
+            org.opencontainers.image.licenses=MIT
+            org.opencontainers.image.version=${{ steps.tags.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke-test image
+        run: |
+          docker run --rm \
+            "ghcr.io/rbmuller/scherlok:${{ steps.tags.outputs.version }}" \
+            version

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,6 +45,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/rbmuller/scherlok:${{ steps.tags.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+# syntax=docker/dockerfile:1.7
+
+# Stage 1: builder
+# Installs scherlok with all source-warehouse extras (dbt, bigquery, snowflake)
+# into a virtual environment. Building in a separate stage keeps build-time
+# dependencies (compilers, dev headers) out of the runtime image.
+FROM python:3.12-slim AS builder
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+WORKDIR /build
+
+# Copy only the metadata first so the dependency install layer caches when
+# only source files change.
+COPY pyproject.toml README.md ./
+COPY src ./src
+
+# Install into a self-contained venv we can copy wholesale into the runtime
+# stage. Includes every optional dependency group so users do not have to
+# rebuild for a different warehouse.
+RUN python -m venv /opt/venv \
+    && /opt/venv/bin/pip install --upgrade pip \
+    && /opt/venv/bin/pip install ".[bigquery,snowflake,dbt]"
+
+# Stage 2: runtime
+# Slim Python base + the installed venv. No build toolchain, no source tree.
+FROM python:3.12-slim AS runtime
+
+ENV PATH="/opt/venv/bin:$PATH" \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+# Copy the prepared virtual environment from the builder.
+COPY --from=builder /opt/venv /opt/venv
+
+# Run as a non-root user. Most CI runners (GitHub Actions, GitLab CI) honor
+# the image's USER directive when the user has not been overridden.
+RUN groupadd --system --gid 1000 scherlok \
+    && useradd --system --uid 1000 --gid scherlok --shell /bin/bash --create-home scherlok
+USER scherlok
+WORKDIR /home/scherlok
+
+ENTRYPOINT ["scherlok"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -265,6 +265,25 @@ pip install scherlok[bigquery]
 
 Requires Python 3.10+.
 
+### Run via Docker
+
+A pre-built image with every warehouse extra (`dbt`, `bigquery`, `snowflake`) is published to GitHub Container Registry on every release tag:
+
+```bash
+docker run --rm ghcr.io/rbmuller/scherlok:latest version
+```
+
+Mount your project directory and inject connection details the same way your CI does it; the entrypoint is the `scherlok` CLI:
+
+```bash
+docker run --rm \
+  -v "$PWD:/work" -w /work \
+  -e SCHERLOK_CONNECTION=postgres://... \
+  ghcr.io/rbmuller/scherlok:latest watch
+```
+
+The image is built from `python:3.12-slim` and runs unprivileged (`USER scherlok`).
+
 ## Contributing
 
 Contributions welcome! See [CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
## Summary

Closes #35

Adds the multi-stage Dockerfile + ghcr.io publish workflow described in the issue, plus a "Run via Docker" subsection in the README.

## What this PR delivers

- **`Dockerfile`** (new) — two stages on `python:3.12-slim`:
  - `builder`: copies `pyproject.toml`, `README.md`, `src/`, then `pip install ".[bigquery,snowflake,dbt]"` into `/opt/venv`. Build deps stay in this stage.
  - `runtime`: copies `/opt/venv` from the builder, runs as a non-root `scherlok` (uid 1000), and entrypoints to the `scherlok` CLI. Default `CMD` is `--help` so an unconfigured `docker run` is informative.
- **`.github/workflows/docker.yml`** (new) — gated on `push` of `v*` tags to match `release.yml`, so non-release branches don't block on a Docker build. Uses `docker/login-action@v3` against ghcr.io with `GITHUB_TOKEN` (no PAT), `docker/build-push-action@v5` with GHA cache, and a smoke test that runs `docker run ... version` against the freshly-pushed image. Tags `{version}` and `latest`, attaches OCI labels.
- **`README.md`** — new "Run via Docker" subsection under "Install" with a `version` smoke command and a mount-and-go `watch` example.

## Acceptance criteria checklist

- [x] New `Dockerfile` at repo root, multi-stage (`builder` + `runtime`), `python:3.12-slim`, installs `[dbt,bigquery,snowflake]`, sets `ENTRYPOINT ["scherlok"]`
- [x] New GitHub Actions workflow at `.github/workflows/docker.yml`, triggers on `v*` tag pushes, builds + pushes to `ghcr.io/rbmuller/scherlok`, uses `docker/build-push-action@v5` with the OIDC `GITHUB_TOKEN`, tags `{version}` and `latest`
- [x] CI does not block on the Docker build for non-tag pushes
- [x] README "Run via Docker" section linking the image
- [ ] Final image size < 100 MB — needs verification on a real build (estimated ~85 MB based on `python:3.12-slim` + scherlok wheel + deps)
- [ ] `docker run --rm ghcr.io/rbmuller/scherlok:latest version` prints the version — needs the first ghcr push to verify; the workflow itself smoke-tests this against the image it just pushed before exiting, so a regression there fails CI

## Notes

I don't have a Windows / Linux Docker host on this machine, so the size and runtime smoke depend on the workflow's own checks on the first tagged release. The Dockerfile itself is `docker buildx`-friendly (declares `# syntax=docker/dockerfile:1.7`) and the workflow keeps GHA cache across builds.

The README example uses `SCHERLOK_CONNECTION` rather than `SCHERLOK_DATABASE_URL` to match what `ScherlokConfig.get_connection_string()` actually reads.
