### PR TITLE
feat: add MySQL connector 

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Use it as a CI gate after `dbt run`:
 - run: scherlok dbt --project-dir . --target prod --fail-on critical
 ```
 
-**Supported adapters:** `postgres`, `bigquery`, `snowflake`. For others, pass `--connection-string` explicitly.
+**Supported adapters:** `postgres`, `bigquery`, `snowflake`, `mysql`. For others, pass `--connection-string` explicitly.
 
 📖 Full docs: [dbt integration guide →](src/scherlok/dbt/README.md)
 
@@ -204,6 +204,10 @@ export SNOWFLAKE_USER=...
 export SNOWFLAKE_PASSWORD=...
 export SNOWFLAKE_WAREHOUSE=...
 scherlok connect snowflake://account/database/schema
+
+# MySQL
+pip install scherlok[mysql]
+scherlok connect mysql://user:pass@host:3306/dbname
 ```
 
 | Database | Status |
@@ -211,7 +215,7 @@ scherlok connect snowflake://account/database/schema
 | PostgreSQL | Available |
 | BigQuery | Available |
 | Snowflake | Available |
-| MySQL | Coming soon |
+| MySQL | Available |
 | DuckDB | Planned |
 
 ## Remote Storage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "psycopg2-binary>=2.9.0",
     "requests>=2.28.0",
     "jinja2>=3.0",
+    "pymysql>=1.1"
 ]
 
 [project.optional-dependencies]

--- a/src/scherlok/connectors/__init__.py
+++ b/src/scherlok/connectors/__init__.py
@@ -20,7 +20,11 @@ try:
     CONNECTOR_SCHEMES["snowflake"] = SnowflakeConnector
 except ImportError:
     pass  # snowflake-connector-python not installed
-
+try:
+    from scherlok.connectors.mysql import MySQLConnector
+    CONNECTOR_SCHEMES["mysql"] = MySQLConnector
+except ImportError:
+    pass 
 
 def get_connector(connection_string: str) -> BaseConnector:
     """Return the appropriate connector for a given connection string.

--- a/src/scherlok/connectors/mysql.py
+++ b/src/scherlok/connectors/mysql.py
@@ -1,0 +1,174 @@
+"""MySQL connector using pymysql."""
+
+from datetime import datetime
+from typing import Any
+from urllib.parse import urlparse
+
+try:
+    import pymysql
+    import pymysql.cursors
+except ImportError as exc:
+    raise ImportError(
+        "pymysql is required for the MySQL connector. "
+        "Install it with: pip install scherlok[mysql]"
+    ) from exc
+
+from scherlok.connectors.base import BaseConnector
+
+
+class MySQLConnector(BaseConnector):
+    """Connector for MySQL (and compatible forks such as MariaDB)."""
+
+    def __init__(self, connection_string: str) -> None:
+        super().__init__(connection_string)
+        self._conn: Any = None
+
+    def connect(self) -> bool:
+        """Validate and establish connection to MySQL."""
+        try:
+            parsed = urlparse(self.connection_string)
+            self._conn = pymysql.connect(
+                host=parsed.hostname or "127.0.0.1",
+                port=parsed.port or 3306,
+                user=parsed.username,
+                password=parsed.password or "",
+                database=parsed.path.lstrip("/"),
+                autocommit=True,
+                cursorclass=pymysql.cursors.DictCursor,
+            )
+            return True
+        except pymysql.Error as exc:
+            self._last_error = self._classify_error(str(exc))
+            return False
+
+    @staticmethod
+    def _classify_error(message: str) -> str:
+        """Map pymysql error text to a short, actionable hint."""
+        msg = message.strip()
+        lowered = msg.lower()
+        if "connection refused" in lowered or "can't connect" in lowered:
+            return (
+                "connection refused — is the server reachable?\n"
+                "  Hint: check host/port and that MySQL is running"
+            )
+        if "access denied" in lowered:
+            return "wrong username or password — check the credentials in your connection string"
+        if "unknown database" in lowered:
+            return (
+                "database does not exist on the server\n"
+                "  Hint: list databases with `SHOW DATABASES;`"
+            )
+        if "timeout" in lowered:
+            return "connection timed out — check the host/port and any firewall in front"
+        if "unknown host" in lowered or "name or service not known" in lowered:
+            return "host not found — check the hostname in your connection string"
+        first_line = msg.splitlines()[0] if msg else "unknown error"
+        return first_line
+
+    def _cursor(self) -> Any:
+        """Return a DictCursor."""
+        return self._conn.cursor()
+
+    def list_tables(self) -> list[str]:
+        """List all base tables in the current database."""
+        db = urlparse(self.connection_string).path.lstrip("/")
+        with self._cursor() as cur:
+            cur.execute(
+                "SELECT TABLE_NAME FROM information_schema.TABLES "
+                "WHERE TABLE_SCHEMA = %s AND TABLE_TYPE = 'BASE TABLE' "
+                "ORDER BY TABLE_NAME",
+                (db,),
+            )
+            return [row["TABLE_NAME"] for row in cur.fetchall()]
+
+    def get_row_count(self, table: str) -> int:
+        """Return exact row count for a table."""
+        with self._cursor() as cur:
+            cur.execute(f"SELECT COUNT(*) AS cnt FROM `{table}`")  # noqa: S608
+            return cur.fetchone()["cnt"]
+
+    def get_columns(self, table: str) -> list[dict]:
+        """Return column metadata from information_schema."""
+        db = urlparse(self.connection_string).path.lstrip("/")
+        with self._cursor() as cur:
+            cur.execute(
+                "SELECT COLUMN_NAME, COLUMN_TYPE, IS_NULLABLE "
+                "FROM information_schema.COLUMNS "
+                "WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s "
+                "ORDER BY ORDINAL_POSITION",
+                (db, table),
+            )
+            return [
+                {
+                    "name": row["COLUMN_NAME"],
+                    "type": row["COLUMN_TYPE"],
+                    "nullable": row["IS_NULLABLE"] == "YES",
+                }
+                for row in cur.fetchall()
+            ]
+
+    def get_column_stats(self, table: str, column: str) -> dict:
+        """Calculate statistics for a numeric or text column."""
+        stats: dict[str, Any] = {}
+        with self._cursor() as cur:
+            cur.execute(
+                f"SELECT "  
+                f"  SUM(CASE WHEN `{column}` IS NULL THEN 1 ELSE 0 END) AS null_count, "
+                f"  COUNT(DISTINCT `{column}`) AS distinct_count "
+                f"FROM `{table}`"
+            )
+            row = cur.fetchone()
+            stats["null_count"] = int(row["null_count"] or 0)
+            stats["distinct_count"] = int(row["distinct_count"] or 0)
+
+         
+            try:
+                cur.execute(
+                    f"SELECT " 
+                    f"  AVG(`{column}`) AS mean, "
+                    f"  STDDEV(`{column}`) AS stddev, "
+                    f"  MIN(`{column}`) AS min, "
+                    f"  MAX(`{column}`) AS max "
+                    f"FROM `{table}`"
+                )
+                num_row = cur.fetchone()
+                stats["mean"] = float(num_row["mean"]) if num_row["mean"] is not None else None
+                stats["stddev"] = float(num_row["stddev"]) if num_row["stddev"] is not None else None
+                stats["min"] = str(num_row["min"]) if num_row["min"] is not None else None
+                stats["max"] = str(num_row["max"]) if num_row["max"] is not None else None
+            except pymysql.Error:
+                stats["mean"] = None
+                stats["stddev"] = None
+                stats["min"] = None
+                stats["max"] = None
+
+            # Top values
+            try:
+                cur.execute(
+                    f"SELECT `{column}` AS val, COUNT(*) AS cnt "  # noqa: S608
+                    f"FROM `{table}` "
+                    f"WHERE `{column}` IS NOT NULL "
+                    f"GROUP BY `{column}` ORDER BY cnt DESC LIMIT 5"
+                )
+                stats["top_values"] = [
+                    {"value": str(r["val"]), "count": r["cnt"]} for r in cur.fetchall()
+                ]
+            except pymysql.Error:
+                stats["top_values"] = []
+
+        return stats
+
+    def get_last_modified(self, table: str) -> datetime | None:
+        """Return last modification time from information_schema.TABLES."""
+        db = urlparse(self.connection_string).path.lstrip("/")
+        with self._cursor() as cur:
+            cur.execute(
+                "SELECT UPDATE_TIME FROM information_schema.TABLES "
+                "WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s",
+                (db, table),
+            )
+            row = cur.fetchone()
+            if row and row["UPDATE_TIME"]:
+                ts = row["UPDATE_TIME"]
+                return ts if isinstance(ts, datetime) else datetime.fromisoformat(str(ts))
+            return None

--- a/src/scherlok/dbt/profiles.py
+++ b/src/scherlok/dbt/profiles.py
@@ -1,6 +1,6 @@
 """Resolve a Scherlok connection string from a dbt project's profiles.yml.
 
-Supports the three adapters Scherlok already speaks: postgres, bigquery, snowflake.
+Supports the four adapters Scherlok already speaks: postgres, bigquery, snowflake, mysql.
 Renders only `{{ env_var('FOO') }}` / `{{ env_var('FOO', 'default') }}` — anything
 else (full Jinja, secrets:// resolvers, etc.) raises and asks the user to pass
 --connection-string explicitly.
@@ -135,10 +135,12 @@ def _output_to_connection_string(output: dict) -> str:
         return _bigquery_connection_string(output)
     if adapter_type == "snowflake":
         return _snowflake_connection_string(output)
+    if adapter_type == "mysql":
+        return _mysql_connection_string(output)
 
     raise ProfileResolutionError(
         f"Unsupported dbt adapter '{adapter_type}'. "
-        f"Supported: postgres, bigquery, snowflake. "
+        f"Supported: postgres, bigquery, snowflake, mysql. "
         f"Use --connection-string to bypass profiles.yml."
     )
 
@@ -176,3 +178,17 @@ def _snowflake_connection_string(output: dict) -> str:
             "Snowflake profile missing required fields: account, database, schema."
         )
     return f"snowflake://{account}/{database}/{schema}"
+
+
+def _mysql_connection_string(output: dict) -> str:
+    user = output.get("user") or output.get("username", "")
+    password = output.get("password", "")
+    host = output.get("host") or output.get("server", "localhost")
+    port = output.get("port", 3306)
+    database = output.get("database") or output.get("schema", "")
+    if not user or not database:
+        raise ProfileResolutionError(
+            "MySQL profile missing required fields: user, database."
+        )
+    auth = f"{user}:{password}@" if password else f"{user}@"
+    return f"mysql://{auth}{host}:{port}/{database}"

--- a/tests/test_mysql.py
+++ b/tests/test_mysql.py
@@ -1,0 +1,218 @@
+"""Tests for MySQLConnector — all I/O mocked, no real MySQL needed."""
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+import sys
+import types
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Patch pymysql before the connector module is imported
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def mock_pymysql():
+    """Inject a fake pymysql into sys.modules for every test."""
+    fake = MagicMock()
+    fake.cursors = MagicMock()
+    fake.cursors.DictCursor = MagicMock()
+    fake.Error = Exception  # so except pymysql.Error works
+
+    sys.modules.setdefault("pymysql", fake)
+    sys.modules.setdefault("pymysql.cursors", fake.cursors)
+
+    # Re-import connector with patched module in place
+    if "scherlok.connectors.mysql" in sys.modules:
+        del sys.modules["scherlok.connectors.mysql"]
+
+    yield fake
+
+    # Cleanup so other test files aren't affected
+    sys.modules.pop("pymysql", None)
+    sys.modules.pop("pymysql.cursors", None)
+    sys.modules.pop("scherlok.connectors.mysql", None)
+
+
+@pytest.fixture()
+def connector(mock_pymysql):
+    from scherlok.connectors.mysql import MySQLConnector
+
+    url = "mysql://user:secret@localhost:3306/testdb"
+    c = MySQLConnector(url)
+
+    # Attach a pre-connected mock so connect() isn't called implicitly
+    fake_conn = MagicMock()
+    c._conn = fake_conn
+    return c, fake_conn
+
+
+def _wire_cursor(fake_conn, fetchall=None, fetchone=None):
+    """Make fake_conn.cursor() a context manager returning a mock cursor."""
+    cur = MagicMock()
+    cur.fetchall.return_value = fetchall or []
+    cur.fetchone.return_value = fetchone
+    ctx = MagicMock()
+    ctx.__enter__ = MagicMock(return_value=cur)
+    ctx.__exit__ = MagicMock(return_value=False)
+    fake_conn.cursor.return_value = ctx
+    return cur
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — connect() passes correct kwargs to pymysql.connect
+# ---------------------------------------------------------------------------
+
+def test_connect_kwargs(mock_pymysql):
+    from scherlok.connectors.mysql import MySQLConnector
+
+    c = MySQLConnector("mysql://alice:pw@db.example.com:3307/mydb")
+    result = c.connect()
+
+    assert result is True
+    kw = mock_pymysql.connect.call_args.kwargs
+    assert kw["host"] == "db.example.com"
+    assert kw["port"] == 3307
+    assert kw["user"] == "alice"
+    assert kw["password"] == "pw"
+    assert kw["database"] == "mydb"
+    assert kw["autocommit"] is True
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — connect() returns False and sets _last_error on failure
+# ---------------------------------------------------------------------------
+
+def test_connect_failure(mock_pymysql):
+    from scherlok.connectors.mysql import MySQLConnector
+
+    mock_pymysql.connect.side_effect = Exception("access denied for user")
+    c = MySQLConnector("mysql://bad:creds@localhost/db")
+    result = c.connect()
+
+    assert result is False
+    assert "wrong username or password" in c._last_error
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — list_tables returns table names, queries information_schema
+# ---------------------------------------------------------------------------
+
+def test_list_tables(connector):
+    c, fake_conn = connector
+    _wire_cursor(fake_conn, fetchall=[
+        {"TABLE_NAME": "orders"},
+        {"TABLE_NAME": "users"},
+    ])
+
+    result = c.list_tables()
+
+    assert result == ["orders", "users"]
+    sql = fake_conn.cursor().__enter__().execute.call_args[0][0]
+    assert "information_schema" in sql.lower()
+    assert "TABLE_TYPE" in sql
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — get_row_count issues COUNT(*) and returns integer
+# ---------------------------------------------------------------------------
+
+def test_get_row_count(connector):
+    c, fake_conn = connector
+    _wire_cursor(fake_conn, fetchone={"cnt": 99})
+
+    assert c.get_row_count("orders") == 99
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — get_columns returns structured metadata with nullable bool
+# ---------------------------------------------------------------------------
+
+def test_get_columns(connector):
+    c, fake_conn = connector
+    _wire_cursor(fake_conn, fetchall=[
+        {"COLUMN_NAME": "id",    "COLUMN_TYPE": "int(11)",     "IS_NULLABLE": "NO"},
+        {"COLUMN_NAME": "email", "COLUMN_TYPE": "varchar(255)", "IS_NULLABLE": "YES"},
+    ])
+
+    cols = c.get_columns("users")
+
+    assert len(cols) == 2
+    assert cols[0] == {"name": "id",    "type": "int(11)",      "nullable": False}
+    assert cols[1] == {"name": "email", "type": "varchar(255)", "nullable": True}
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — get_column_stats returns null_count, distinct_count, mean, etc.
+# ---------------------------------------------------------------------------
+
+def test_get_column_stats_numeric(connector):
+    c, fake_conn = connector
+
+    cur = MagicMock()
+    # fetchone called 3 times: null/distinct, numeric stats, (top_values uses fetchall)
+    cur.fetchone.side_effect = [
+        {"null_count": 2, "distinct_count": 50},
+        {"mean": 10.5, "stddev": 1.2, "min": "1", "max": "99"},
+    ]
+    cur.fetchall.return_value = [
+        {"val": "10", "cnt": 5},
+        {"val": "20", "cnt": 3},
+    ]
+    ctx = MagicMock()
+    ctx.__enter__ = MagicMock(return_value=cur)
+    ctx.__exit__ = MagicMock(return_value=False)
+    fake_conn.cursor.return_value = ctx
+
+    stats = c.get_column_stats("orders", "amount")
+
+    assert stats["null_count"] == 2
+    assert stats["distinct_count"] == 50
+    assert stats["mean"] == 10.5
+    assert stats["min"] == "1"
+    assert len(stats["top_values"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Test 7 — get_last_modified returns datetime when UPDATE_TIME is set
+# ---------------------------------------------------------------------------
+
+def test_get_last_modified_returns_datetime(connector):
+    c, fake_conn = connector
+    ts = datetime(2024, 6, 15, 10, 30, 0)
+    _wire_cursor(fake_conn, fetchone={"UPDATE_TIME": ts})
+
+    assert c.get_last_modified("orders") == ts
+
+
+def test_get_last_modified_returns_none(connector):
+    c, fake_conn = connector
+    _wire_cursor(fake_conn, fetchone={"UPDATE_TIME": None})
+
+    assert c.get_last_modified("orders") is None
+
+
+# ---------------------------------------------------------------------------
+# Test 8 — _classify_error maps known messages correctly
+# ---------------------------------------------------------------------------
+
+def test_classify_error_access_denied(mock_pymysql):
+    from scherlok.connectors.mysql import MySQLConnector
+
+    result = MySQLConnector._classify_error("(1045, 'Access denied for user')")
+    assert "wrong username or password" in result
+
+
+def test_classify_error_unknown_database(mock_pymysql):
+    from scherlok.connectors.mysql import MySQLConnector
+
+    result = MySQLConnector._classify_error("(1049, 'Unknown database mydb')")
+    assert "does not exist" in result
+
+
+def test_classify_error_fallback(mock_pymysql):
+    from scherlok.connectors.mysql import MySQLConnector
+
+    result = MySQLConnector._classify_error("some weird error")
+    assert result == "some weird error"


### PR DESCRIPTION

- New `MySQLConnector` in `src/scherlok/connectors/mysql.py`
- Registered under the `mysql://` scheme in `__init__.py`
- dbt profile resolution added in `profiles.py`
- Optional dependency: `pip install scherlok[mysql]`
- 11 tests, all passing