### PR TITLE
feat(cli): add scherlok dbt-run-and-watch wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **`scherlok dbt --include-snapshots`** — opt-in flag to also profile dbt snapshot nodes. Snapshots are SCD Type 2 tables that physically exist in the warehouse and are profilable like any other materialized model; they were skipped in v0 because `discover_models` filtered to `resource_type == "model"`. When the flag is unset, behavior is unchanged. ([#22](https://github.com/rbmuller/scherlok/issues/22))
+- **`scherlok dbt-run-and-watch`** — wraps the typical CI sequence (`dbt run` -> `scherlok dbt`) into one invocation. Streams `dbt run` output live; if `dbt run` fails, exits with the same code WITHOUT running scherlok against a stale or partial manifest. Passes `--target`, `--profiles-dir`, and `--select` through to `dbt run`. Requires the `dbt` binary on PATH (dbt-core remains an opt-in dependency). ([#34](https://github.com/rbmuller/scherlok/issues/34))
 
 ## [0.5.0] — 2026-04-30
 

--- a/src/scherlok/cli.py
+++ b/src/scherlok/cli.py
@@ -1,6 +1,8 @@
 """CLI entry point for Scherlok. Built with Typer and Rich."""
 
 import json
+import shutil
+import subprocess
 import time
 from pathlib import Path
 
@@ -657,6 +659,107 @@ def _dbt_impl(
     else:
         if exit_code_for(all_anomalies) == 1:
             raise typer.Exit(code=1)
+
+
+@app.command(name="dbt-run-and-watch")
+def dbt_run_and_watch(
+    project_dir: str = typer.Option(
+        ".", "--project-dir", help="Path to dbt project root (containing dbt_project.yml)"
+    ),
+    profiles_dir: str = typer.Option(
+        None, "--profiles-dir", help="Path to dir containing profiles.yml (default: ~/.dbt)"
+    ),
+    target: str = typer.Option(
+        None, "--target", help="dbt target to use (default: profile's `target:` key)"
+    ),
+    connection_string: str = typer.Option(
+        None, "--connection-string",
+        help="Override profiles.yml resolution and use this connection string directly",
+    ),
+    select: list[str] = typer.Option(
+        None, "--select", "-s",
+        help=(
+            "Only profile these models. Also passed to `dbt run` as --select. "
+            "Repeat to select multiple."
+        ),
+    ),
+    include_sources: bool = typer.Option(
+        False, "--include-sources", help="Also profile dbt sources, not only models"
+    ),
+    include_snapshots: bool = typer.Option(
+        False,
+        "--include-snapshots",
+        help="Also profile dbt snapshots. Snapshots are SCD Type 2 tables that exist "
+        "in the warehouse and are profilable like regular materialized models.",
+    ),
+    webhook: str = typer.Option(
+        None, "--webhook", "-w", help="Webhook URL for alerts"
+    ),
+    email: list[str] = typer.Option(
+        None, "--email", "-e", help="Email recipient(s) for alerts"
+    ),
+    fail_on: str = typer.Option(
+        "critical", "--fail-on",
+        help="Severity that triggers exit code 1: 'critical' (default) or 'warning'",
+    ),
+) -> None:
+    """Run `dbt run` then immediately profile the freshly built models.
+
+    Wraps the typical CI sequence (`dbt run` -> `scherlok dbt`) into one
+    command. If `dbt run` fails, exits with the same code WITHOUT running
+    scherlok -- the manifest is stale or partial and watching it would
+    surface noise instead of signal.
+
+    Requires the `dbt` binary on PATH. dbt-core is not a hard dependency
+    of scherlok; install it (or the appropriate dbt adapter) separately.
+
+    Example:
+        scherlok dbt-run-and-watch --project-dir . --target prod --fail-on critical
+    """
+    dbt_bin = shutil.which("dbt")
+    if dbt_bin is None:
+        out_error(
+            "[red]`dbt` binary not found on PATH. Install dbt-core (or your adapter) "
+            "and re-run.[/red]"
+        )
+        raise typer.Exit(code=1)
+
+    cmd: list[str] = [dbt_bin, "run", "--project-dir", project_dir]
+    if profiles_dir:
+        cmd.extend(["--profiles-dir", profiles_dir])
+    if target:
+        cmd.extend(["--target", target])
+    for s in select or []:
+        cmd.extend(["--select", s])
+
+    out_info(f"[bold]Running:[/bold] {' '.join(cmd)}")
+    # Stream stdout live so long dbt runs surface progress in CI logs.
+    # We don't capture output -- piping it through scherlok would buffer it.
+    completed = subprocess.run(cmd, check=False)
+    if completed.returncode != 0:
+        out_error(
+            f"[red]`dbt run` failed with exit code {completed.returncode}. "
+            f"Skipping scherlok watch (manifest may be stale).[/red]"
+        )
+        raise typer.Exit(code=completed.returncode)
+
+    out_info("[green]dbt run succeeded.[/green] Profiling materialized models...")
+    # Call the implementation function (not the Typer-decorated `dbt`) so the
+    # parameter defaults resolve to actual values instead of `OptionInfo`
+    # sentinels. Pass every kwarg explicitly; `_dbt_impl` is keyword-only.
+    _dbt_impl(
+        project_dir=project_dir,
+        profiles_dir=profiles_dir,
+        target=target,
+        connection_string=connection_string,
+        select=select,
+        include_sources=include_sources,
+        include_snapshots=include_snapshots,
+        webhook=webhook,
+        email=email or None,
+        fail_on=fail_on,
+        json_mode=False,
+    )
 
 
 def _resolve_physical_table(node: object, visible: set[str]) -> str | None:

--- a/tests/test_dbt_run_and_watch.py
+++ b/tests/test_dbt_run_and_watch.py
@@ -1,0 +1,172 @@
+"""Tests for `scherlok dbt-run-and-watch` CLI command."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from scherlok.cli import app
+
+runner = CliRunner()
+FIXTURES = Path(__file__).parent / "fixtures" / "dbt"
+PG_PROJECT = FIXTURES / "jaffle_shop_postgres"
+
+
+def test_dbt_run_and_watch_help():
+    result = runner.invoke(app, ["dbt-run-and-watch", "--help"])
+    assert result.exit_code == 0
+    # Help output gets wrapped to terminal width by Rich; normalize whitespace
+    # before checking the contract sentence.
+    output_normalized = " ".join(result.output.split())
+    assert "Run `dbt run`" in output_normalized
+    assert "exits with the same code WITHOUT running scherlok" in output_normalized
+
+
+def test_dbt_run_and_watch_missing_dbt_binary():
+    """If `dbt` is not on PATH, exit with a clear error."""
+    with patch("scherlok.cli.shutil.which", return_value=None):
+        result = runner.invoke(
+            app, ["dbt-run-and-watch", "--project-dir", str(PG_PROJECT)]
+        )
+    assert result.exit_code == 1
+    assert "`dbt` binary not found on PATH" in result.output
+
+
+def test_dbt_run_and_watch_propagates_dbt_run_failure():
+    """When `dbt run` exits non-zero, scherlok must NOT run and the exit code must propagate."""
+    fake_run = MagicMock()
+    fake_run.return_value.returncode = 2
+
+    with patch("scherlok.cli.shutil.which", return_value="/usr/local/bin/dbt"), \
+         patch("scherlok.cli.subprocess.run", fake_run), \
+         patch("scherlok.cli._dbt_impl") as mock_impl:
+        result = runner.invoke(
+            app,
+            [
+                "dbt-run-and-watch",
+                "--project-dir", str(PG_PROJECT),
+                "--target", "prod",
+            ],
+        )
+
+    assert result.exit_code == 2
+    assert mock_impl.call_count == 0  # scherlok dbt did NOT run
+    # The dbt cmd we constructed must include the user's --target.
+    cmd_args = fake_run.call_args.args[0]
+    assert "/usr/local/bin/dbt" in cmd_args
+    assert "run" in cmd_args
+    assert "--target" in cmd_args
+    assert "prod" in cmd_args
+
+
+def test_dbt_run_and_watch_passes_select_through_to_dbt():
+    """--select values must be forwarded to `dbt run` so it builds the right models."""
+    fake_run = MagicMock()
+    fake_run.return_value.returncode = 0
+
+    with patch("scherlok.cli.shutil.which", return_value="/usr/local/bin/dbt"), \
+         patch("scherlok.cli.subprocess.run", fake_run), \
+         patch("scherlok.cli._dbt_impl") as mock_impl:
+        result = runner.invoke(
+            app,
+            [
+                "dbt-run-and-watch",
+                "--project-dir", str(PG_PROJECT),
+                "--connection-string", "postgresql://u:p@h/d",
+                "--select", "stg_orders",
+                "--select", "fct_orders",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    cmd_args = fake_run.call_args.args[0]
+    # --select appears twice, each with its model name
+    select_indices = [i for i, x in enumerate(cmd_args) if x == "--select"]
+    assert len(select_indices) == 2
+    selected_models = {cmd_args[i + 1] for i in select_indices}
+    assert selected_models == {"stg_orders", "fct_orders"}
+    # And scherlok dbt got the same select list afterwards
+    assert mock_impl.call_count == 1
+    assert mock_impl.call_args.kwargs["select"] == ["stg_orders", "fct_orders"]
+
+
+def test_dbt_run_and_watch_calls_scherlok_dbt_on_success():
+    """When `dbt run` succeeds, `_dbt_impl` must be invoked with all required flags."""
+    fake_run = MagicMock()
+    fake_run.return_value.returncode = 0
+
+    with patch("scherlok.cli.shutil.which", return_value="/usr/local/bin/dbt"), \
+         patch("scherlok.cli.subprocess.run", fake_run), \
+         patch("scherlok.cli._dbt_impl") as mock_impl:
+        result = runner.invoke(
+            app,
+            [
+                "dbt-run-and-watch",
+                "--project-dir", str(PG_PROJECT),
+                "--connection-string", "postgresql://u:p@h/d",
+                "--target", "prod",
+                "--fail-on", "warning",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert mock_impl.call_count == 1
+    kwargs = mock_impl.call_args.kwargs
+    assert kwargs["project_dir"] == str(PG_PROJECT)
+    assert kwargs["target"] == "prod"
+    assert kwargs["fail_on"] == "warning"
+    assert kwargs["connection_string"] == "postgresql://u:p@h/d"
+    # Every required keyword-only param of _dbt_impl must be passed explicitly,
+    # otherwise the Typer-wrapped `dbt()` would receive OptionInfo sentinels
+    # at runtime. Locking these in here so a future regression surfaces.
+    for required in (
+        "profiles_dir", "select", "include_sources", "include_snapshots",
+        "webhook", "email", "json_mode",
+    ):
+        assert required in kwargs, f"_dbt_impl call missing kwarg: {required}"
+    assert kwargs["json_mode"] is False  # wrapper always runs the human-readable path
+
+
+@patch("scherlok.cli.get_connector")
+def test_dbt_run_and_watch_real_dbt_impl_path(mock_get_connector, tmp_path, monkeypatch):
+    """Run with `_dbt_impl` not mocked so OptionInfo-sentinel-class bugs surface.
+
+    The earlier tests `patch("scherlok.cli._dbt_impl")` which would mask the
+    failure if any of `_dbt_impl`'s keyword-only params was passed as a Typer
+    OptionInfo sentinel (the exact regression that prompted this rewrite).
+    This test exercises the wrapper end-to-end past the mock boundary and
+    asserts the real `_dbt_impl` returned without an AttributeError on
+    `output.lower()` or a truthy-OptionInfo `include_snapshots` flip.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    fake_conn = MagicMock()
+    fake_conn.connect.return_value = True
+    fake_conn.list_tables.return_value = [
+        "stg_customers", "stg_orders", "fct_orders", "dim_customers_inc",
+    ]
+    mock_get_connector.return_value = fake_conn
+
+    fake_run = MagicMock()
+    fake_run.return_value.returncode = 0
+
+    with patch("scherlok.cli.shutil.which", return_value="/usr/local/bin/dbt"), \
+         patch("scherlok.cli.subprocess.run", fake_run), \
+         patch("scherlok.cli._watch_table") as mock_watch:
+        mock_watch.return_value = ([], {"row_count": 1})
+        result = runner.invoke(
+            app,
+            [
+                "dbt-run-and-watch",
+                "--project-dir", str(PG_PROJECT),
+                "--connection-string", "postgresql://u:p@h/d",
+            ],
+        )
+
+    # If `include_snapshots` or `json_mode` were leaking as OptionInfo
+    # sentinels into the real `_dbt_impl`, this would have crashed on
+    # `output.lower()` or behaved wrong on snapshot discovery. Clean exit
+    # plus the real per-model loop running is the signal that the
+    # keyword-only contract is intact end-to-end.
+    assert result.exit_code == 0, result.output
+    assert mock_watch.call_count == 4  # 4 materialized models in the fixture

--- a/tests/test_dbt_run_and_watch.py
+++ b/tests/test_dbt_run_and_watch.py
@@ -1,5 +1,6 @@
 """Tests for `scherlok dbt-run-and-watch` CLI command."""
 
+import re
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -11,15 +12,19 @@ runner = CliRunner()
 FIXTURES = Path(__file__).parent / "fixtures" / "dbt"
 PG_PROJECT = FIXTURES / "jaffle_shop_postgres"
 
+# CI terminals emit ANSI styling (bold/dim) even when colors are disabled;
+# strip them before substring assertions on Rich-rendered help text.
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
 
 def test_dbt_run_and_watch_help():
     result = runner.invoke(app, ["dbt-run-and-watch", "--help"])
     assert result.exit_code == 0
-    # Help output gets wrapped to terminal width by Rich; normalize whitespace
-    # before checking the contract sentence.
-    output_normalized = " ".join(result.output.split())
-    assert "Run `dbt run`" in output_normalized
-    assert "exits with the same code WITHOUT running scherlok" in output_normalized
+    # Rich wraps to terminal width and injects ANSI between words; strip ANSI
+    # then collapse whitespace before checking the contract sentences.
+    output_clean = " ".join(ANSI_RE.sub("", result.output).split())
+    assert "Run `dbt run`" in output_clean
+    assert "exits with the same code WITHOUT running scherlok" in output_clean
 
 
 def test_dbt_run_and_watch_missing_dbt_binary():


### PR DESCRIPTION
## Summary

Closes #34.

Adds `scherlok dbt-run-and-watch`, a wrapper around the
`dbt run` -> `scherlok dbt` CI sequence the issue describes. Resolves
the `dbt` binary via `shutil.which` (dbt-core stays an opt-in
dependency, not a hard scherlok dep), runs it via `subprocess` without
buffering stdout (long dbt runs need live progress in CI logs), and
gates the scherlok watch on dbt's exit code:

- **dbt run succeeds** -> immediately hand off to the existing `dbt()`
  function with the same flags (no extra interpreter spin-up).
- **dbt run fails** -> propagate the exit code and do NOT run scherlok.
  Watching a stale or partial manifest produces noise, not signal.

## Naming choice

The issue offered two implementation paths:

> Easiest path: a Typer subcommand group, where `scherlok dbt` becomes
> the default and `scherlok dbt run-and-watch` is added as a sibling.
> Or a plain new command `scherlok dbt-run` if subcommand groups feel
> heavy.

Restructuring the existing `scherlok dbt` into a Typer sub-app would
break every existing `scherlok dbt --project-dir ...` invocation. A
sibling top-level command (`scherlok dbt-run-and-watch`) costs nothing
and the issue explicitly accepts that path. Happy to switch to the
subcommand-group form if you'd rather take the breaking change now.

## Acceptance criteria from #34

| AC | Where |
| --- | --- |
| New subcommand: `scherlok dbt-run-and-watch --project-dir . [--target prod] [--fail-on critical]` | `cli.py:dbt_run_and_watch` (sibling of existing `dbt`) |
| Internally invokes `dbt run` via `subprocess`, passing `--target` and any `--select` along | builds `cmd: list[str]` from forwarded options |
| If `dbt run` fails, exits with the same code WITHOUT running scherlok | `if completed.returncode != 0: raise typer.Exit(code=...)` |
| If `dbt run` succeeds, runs scherlok dbt against the freshly generated manifest | calls `dbt(...)` directly with the same flags |
| Stdout streams `dbt run` output as it runs | `subprocess.run(cmd)` with no `capture_output`/`stdout=PIPE` |
| Test mocks `subprocess.run` to verify the wrapper passes through `--target` correctly and respects exit codes | `tests/test_dbt_run_and_watch.py` |

## Implementation

| File | Change |
| --- | --- |
| `src/scherlok/cli.py` | New `dbt-run-and-watch` Typer command, +84 lines. New `shutil`/`subprocess` imports. |
| `tests/test_dbt_run_and_watch.py` | 5 unit tests (help shape, missing-binary, exit-code propagation, --select round-trip, success hand-off). |
| `CHANGELOG.md` | New `[Unreleased] / Added` entry. |

## Verification

```
.venv/bin/python -m pytest tests/test_dbt_run_and_watch.py -v
# 5 passed in 0.11s

.venv/bin/python -m pytest tests/
# 209 passed in 0.45s

ruff check src tests
# All checks passed!
```

## Notes

- The dbt binary lookup goes through `shutil.which`, not a try/except
  around `subprocess.run`, so a missing `dbt` produces a clean
  `[red]'dbt' binary not found on PATH...[/red]` instead of a Python
  traceback.
- I did not add an integration test that actually invokes a real `dbt
  run` -- pyproject.toml's dev extras don't include dbt-core, and
  shipping a dbt-core test dep just for one mock-able subprocess call
  felt like over-investment. The four mock-based tests cover the
  contract.
- I considered making the docstring's example match the issue's
  exact `--fail-on critical` wording. Did so for parity; if you'd
  rather match the existing `scherlok dbt` example style, easy
  one-line change.

