### PR TITLE
feat(dbt): add --output json for CI parsers

### DIFF
--- a/src/scherlok/cli.py
+++ b/src/scherlok/cli.py
@@ -1,5 +1,6 @@
 """CLI entry point for Scherlok. Built with Typer and Rich."""
 
+import json
 import time
 from pathlib import Path
 
@@ -427,6 +428,10 @@ def dbt(
         "critical", "--fail-on",
         help="Severity that triggers exit code 1: 'critical' (default) or 'warning'",
     ),
+    output: str = typer.Option(
+        "text", "--output",
+        help="Output format: 'text' (default) or 'json' for CI parsers",
+    ),
 ) -> None:
     """Profile and watch dbt models. Reads target/manifest.json.
 
@@ -437,7 +442,68 @@ def dbt(
         scherlok dbt --project-dir ./my_dbt_project
         scherlok dbt --project-dir . --select stg_orders --select fct_orders
         scherlok dbt --project-dir . --connection-string postgresql://...
+        scherlok dbt --project-dir . --output json  # CI-parseable stdout
     """
+    output_lower = output.lower()
+    if output_lower not in ("text", "json"):
+        console.print(
+            f"[red]Invalid --output value '{output}'. Use 'text' or 'json'.[/red]"
+        )
+        raise typer.Exit(code=1)
+    json_mode = output_lower == "json"
+
+    from scherlok.output import is_quiet, set_stderr, set_verbosity
+    prev_quiet = is_quiet()
+    if json_mode:
+        # Reroute Rich chatter to stderr so stdout stays exclusively for the
+        # JSON payload emitted at the end of this command. The module-level
+        # console is shared, so the restore in the finally block below is
+        # what keeps subsequent commands (and subsequent tests) untouched.
+        set_stderr(True)
+        # _dispatch_alerts gates its Rich anomaly-table print on is_quiet();
+        # flip that on for the duration of the json run so the table never
+        # appears on stderr alongside the JSON payload either.
+        set_verbosity(quiet=True)
+
+    try:
+        _dbt_impl(
+            project_dir=project_dir,
+            profiles_dir=profiles_dir,
+            target=target,
+            connection_string=connection_string,
+            select=select,
+            include_sources=include_sources,
+            include_snapshots=include_snapshots,
+            webhook=webhook,
+            email=email,
+            fail_on=fail_on,
+            json_mode=json_mode,
+        )
+    finally:
+        if json_mode:
+            set_stderr(False)
+            set_verbosity(quiet=prev_quiet)
+
+
+def _dbt_impl(
+    *,
+    project_dir: str,
+    profiles_dir: str | None,
+    target: str | None,
+    connection_string: str | None,
+    select: list[str] | None,
+    include_sources: bool,
+    include_snapshots: bool,
+    webhook: str | None,
+    email: list[str] | None,
+    fail_on: str,
+    json_mode: bool,
+) -> None:
+    """The actual dbt-command body. Extracted so the `dbt()` entry point can
+    wrap it in a try/finally that restores the shared output console after
+    JSON-mode rerouting -- the entry point keeps the Typer surface and the
+    flag parsing; this function does the work."""
+
     from scherlok.dbt import (
         DbtNode,
         ProfileResolutionError,
@@ -517,22 +583,40 @@ def dbt(
     # 4. Per-model investigate + watch
     from scherlok.config import PROFILES_DB
     all_anomalies: list[dict] = []
+    json_models: list[dict] = []
     with sync_context(cfg.get_store(), PROFILES_DB):
         store = ProfileStore()
         for node, physical in matched:
             table_anomalies, current_vol = _watch_table(connector, store, physical)
             all_anomalies.extend(table_anomalies)
-            _print_dbt_model_result(node, physical, current_vol, table_anomalies)
+            if json_mode:
+                json_models.append(_dbt_model_payload(node, physical, current_vol, table_anomalies))
+            else:
+                _print_dbt_model_result(node, physical, current_vol, table_anomalies)
         _dispatch_alerts(all_anomalies, store, webhook, email or None)
 
     # 5. Summary + exit code
     crit = sum(1 for a in all_anomalies if str(a.get("severity")).endswith("CRITICAL"))
     warn = sum(1 for a in all_anomalies if str(a.get("severity")).endswith("WARNING"))
-    out_info(
-        f"\n[bold]Summary:[/bold] {len(matched)} profiled, "
-        f"{len(all_anomalies)} anomalies "
-        f"([red]{crit} critical[/red], [yellow]{warn} warning[/yellow])"
-    )
+    if json_mode:
+        payload = {
+            "project_dir": project_dir,
+            "adapter": adapter,
+            "models": json_models,
+            "summary": {
+                "profiled": len(matched),
+                "anomalies": len(all_anomalies),
+                "critical": crit,
+                "warning": warn,
+            },
+        }
+        print(json.dumps(payload))
+    else:
+        out_info(
+            f"\n[bold]Summary:[/bold] {len(matched)} profiled, "
+            f"{len(all_anomalies)} anomalies "
+            f"([red]{crit} critical[/red], [yellow]{warn} warning[/yellow])"
+        )
 
     fail_on_lower = fail_on.lower()
     if fail_on_lower == "warning":
@@ -558,6 +642,31 @@ def _resolve_physical_table(node: object, visible: set[str]) -> str | None:
         if cand and cand in visible:
             return cand
     return None
+
+
+def _dbt_model_payload(
+    node: object, physical: str, current_vol: dict, anomalies: list[dict]
+) -> dict:
+    """Serialize one dbt model's profile + anomalies for `--output json`.
+
+    Enum severities serialize as their bare name (e.g. `"CRITICAL"` rather
+    than `"Severity.CRITICAL"`) so the JSON contract is stable regardless
+    of how the detector module spells the value.
+    """
+    return {
+        "name": node.name,  # type: ignore[attr-defined]
+        "physical": physical,
+        "resource_type": getattr(node, "resource_type", "model"),
+        "row_count": current_vol.get("row_count"),
+        "anomalies": [
+            {
+                "severity": str(a.get("severity")).rsplit(".", 1)[-1],
+                "type": a.get("type"),
+                "message": a.get("message"),
+            }
+            for a in anomalies
+        ],
+    }
 
 
 def _print_dbt_model_result(

--- a/src/scherlok/output.py
+++ b/src/scherlok/output.py
@@ -6,6 +6,10 @@ then call `info()` / `verbose_info()` / `error()` from anywhere in the CLI.
 - `info(msg)` — printed unless `--quiet`. Default user-facing output.
 - `verbose_info(msg)` — printed only when `--verbose`. Diagnostics, timings.
 - `error(msg)` — always printed, regardless of `--quiet`. Failures and warnings.
+
+Commands that need a JSON-only stdout (e.g. `scherlok dbt --output json`) can
+call `set_stderr(True)` to redirect every info/error message to stderr,
+keeping stdout reserved for the machine-readable payload.
 """
 
 from rich.console import Console
@@ -56,3 +60,19 @@ def error(msg: str) -> None:
 def get_console() -> Console:
     """Return the underlying Rich Console (for advanced cases like Tables)."""
     return _console
+
+
+def set_stderr(enabled: bool) -> None:
+    """Route every info/verbose/error message to stderr instead of stdout.
+
+    Use when stdout must stay machine-parseable (e.g. `scherlok dbt
+    --output json` emits a single JSON object on stdout and needs every
+    Rich progress line out of the way). Idempotent.
+
+    Pair with a try/finally that calls `set_stderr(False)` to restore the
+    default stdout console -- the module-level `_console` is shared, and
+    leaving it pointed at stderr would silently change every subsequent
+    command (and every subsequent test) in the same process.
+    """
+    global _console
+    _console = Console(stderr=enabled)

--- a/tests/test_dbt_cli.py
+++ b/tests/test_dbt_cli.py
@@ -1,5 +1,6 @@
 """Tests for `scherlok dbt` CLI command."""
 
+import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -129,3 +130,108 @@ def test_dbt_select_filters_models(mock_get_connector, tmp_path, monkeypatch):
     # Exactly fct_orders profiled
     called_table = mock_watch.call_args.args[2]
     assert called_table == "fct_orders"
+
+
+@patch("scherlok.cli.get_connector")
+def test_dbt_output_json_emits_parseable_object(mock_get_connector, tmp_path, monkeypatch):
+    """`--output json` emits a single JSON object on stdout with the documented shape."""
+    from scherlok.detector.severity import Severity
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    fake = MagicMock()
+    fake.connect.return_value = True
+    fake.list_tables.return_value = [
+        "stg_customers", "stg_orders", "fct_orders", "dim_customers_inc",
+    ]
+    mock_get_connector.return_value = fake
+
+    sample_anomaly = {
+        "table": "stg_customers",
+        "severity": Severity.CRITICAL,
+        "type": "volume_drop",
+        "message": "row count fell 90%",
+    }
+    with patch("scherlok.cli._watch_table") as mock_watch:
+        # First model carries an anomaly so summary counts non-zero criticals.
+        mock_watch.side_effect = [
+            ([sample_anomaly], {"row_count": 4}),
+            ([], {"row_count": 100}),
+            ([], {"row_count": 200}),
+            ([], {"row_count": 300}),
+        ]
+        result = runner.invoke(
+            app,
+            [
+                "dbt",
+                "--project-dir", str(PG_PROJECT),
+                "--connection-string", "postgresql://u:p@host/db",
+                "--output", "json",
+            ],
+        )
+
+    # Default --fail-on=critical exits 1 on the CRITICAL anomaly; the JSON
+    # must still have landed on stdout before that exit.
+    assert result.stdout.strip().startswith("{"), f"stdout not json: {result.stdout!r}"
+    payload = json.loads(result.stdout)
+    assert payload["project_dir"] == str(PG_PROJECT)
+    assert payload["adapter"] == "postgres"
+    assert isinstance(payload["models"], list)
+    assert len(payload["models"]) == 4
+    first = payload["models"][0]
+    assert set(first.keys()) >= {"name", "physical", "resource_type", "row_count", "anomalies"}
+    assert first["anomalies"][0]["severity"] == "CRITICAL"
+    assert first["anomalies"][0]["type"] == "volume_drop"
+    summary = payload["summary"]
+    assert set(summary.keys()) >= {"profiled", "anomalies", "critical", "warning"}
+    assert summary["profiled"] == 4
+    assert summary["anomalies"] == 1
+    assert summary["critical"] == 1
+    assert summary["warning"] == 0
+
+
+@patch("scherlok.cli.get_connector")
+def test_dbt_output_json_keeps_stdout_clean(mock_get_connector, tmp_path, monkeypatch):
+    """No Rich `Investigating ...` or `Summary:` chatter leaks into stdout when --output json."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    fake = MagicMock()
+    fake.connect.return_value = True
+    fake.list_tables.return_value = [
+        "stg_customers", "stg_orders", "fct_orders", "dim_customers_inc",
+    ]
+    mock_get_connector.return_value = fake
+
+    with patch("scherlok.cli._watch_table") as mock_watch:
+        mock_watch.return_value = ([], {"row_count": 1})
+        result = runner.invoke(
+            app,
+            [
+                "dbt",
+                "--project-dir", str(PG_PROJECT),
+                "--connection-string", "postgresql://u:p@host/db",
+                "--output", "json",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Investigating" not in result.stdout
+    assert "Summary:" not in result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["summary"]["anomalies"] == 0
+
+
+def test_dbt_output_invalid_value_rejected(tmp_path, monkeypatch):
+    """Unknown --output values exit 1 with a clear message."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    result = runner.invoke(
+        app,
+        [
+            "dbt",
+            "--project-dir", str(PG_PROJECT),
+            "--connection-string", "postgresql://u:p@host/db",
+            "--output", "yaml",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "Invalid --output" in result.output


### PR DESCRIPTION
## Summary

`scherlok dbt` prints a Rich table that's great for humans but hard for CI tooling to consume. Add an opt-in `--output json` that emits a single JSON object to stdout matching the shape the issue documents, and keeps stdout free of Rich chatter so `json.loads` works as the first thing a CI script does with the output.

Closes #33

## Why this matters

Anomaly detection only ends up in CI dashboards if a parser can read the output. The Rich table is great for terminal humans, but a CI step that wants to file an issue or annotate a PR with each `fct_orders` regression has to scrape ANSI-flavored ASCII art. The new flag turns the same data into a structured payload without changing the default behavior. The default text output is byte-identical when the flag is absent.

## What changes

`src/scherlok/output.py` gains `set_stderr(True/False)`, a small helper that swaps the module-level Rich Console for a stderr-bound one. This is the single switch every `out_info` / `out_error` path already routes through, so flipping it once routes every progress and warning line off stdout for the duration of the JSON run.

`src/scherlok/cli.py` adds `--output text|json` to the `dbt` command (default `text`). When `--output json`:

1. Validates the value up front and exits 1 on anything other than `text` / `json`.
2. Flips `set_stderr(True)` so every Rich line goes to stderr.
3. Flips `set_verbosity(quiet=True)` so `_dispatch_alerts` skips its own Rich anomaly table (that helper has its own Console object that doesn't go through `set_stderr`; `quiet=True` is the existing gate it already checks).
4. Runs the existing per-model loop, but buffers each model's result via a new `_dbt_model_payload(...)` helper (`name`, `physical`, `resource_type`, `row_count`, `anomalies[]`) instead of calling `_print_dbt_model_result`.
5. After the loop, prints one `json.dumps(payload)` line to stdout. Payload shape matches the issue body exactly: `project_dir`, `adapter`, `models[]`, `summary{profiled, anomalies, critical, warning}`.

Step 1 is wrapped in a `try/finally` that restores `set_stderr(False)` and the previous verbosity. The module-level console is shared, so without the restore one `--output json` invocation would silently redirect every subsequent command (and every subsequent test) in the same process to stderr.

`fail_on` semantics and exit codes are unchanged; the JSON gets emitted before the exit code applies, so a CI step can parse the payload and still see exit 1 on critical anomalies.

`tests/test_dbt_cli.py` adds three cases:

- `test_dbt_output_json_emits_parseable_object` mocks `_watch_table` with a `Severity.CRITICAL` volume_drop on the first model, parses stdout with `json.loads`, and asserts the full shape (top-level keys, model fields, anomaly fields, summary counters).
- `test_dbt_output_json_keeps_stdout_clean` asserts no `Investigating` or `Summary:` chatter leaks into stdout when `--output json`.
- `test_dbt_output_invalid_value_rejected` covers the early-exit for unsupported formats.

## Verification

`PYTHONPATH=src .venv/bin/python -m pytest tests/test_dbt_cli.py -v` -> 9 passed (3 new + 6 existing). No production behavior changes when the flag is absent.

## Risk

Low. New optional flag; default text path unchanged. The shared console swap is scoped to the dbt command via try/finally so the state cannot leak.
