### PR TITLE
ci(docker): fail release on linux/amd64 image > 100 MiB

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,6 +15,13 @@ on:
 permissions:
   contents: read
 
+# Catch dependency bloat early: if a new transitive dep silently doubles the
+# image, fail the publish before a release tag goes out. The current image
+# (python:3.12-slim + scherlok wheel + warehouse extras) sits ~85-95 MiB, so
+# 100 MiB is a small headroom and not a stretch target.
+env:
+  MAX_IMAGE_SIZE_BYTES: 104857600
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -57,6 +64,28 @@ jobs:
             org.opencontainers.image.version=${{ steps.tags.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Assert image size under ceiling (linux/amd64)
+        env:
+          IMAGE_REF: ghcr.io/rbmuller/scherlok:${{ steps.tags.outputs.version }}
+        run: |
+          set -euo pipefail
+          digest=$(docker buildx imagetools inspect "$IMAGE_REF" --raw \
+            | jq -r '.manifests[] | select(.platform.architecture == "amd64" and .platform.os == "linux") | .digest')
+          if [ -z "$digest" ] || [ "$digest" = "null" ]; then
+            echo "::error::Could not resolve linux/amd64 manifest for $IMAGE_REF"
+            exit 1
+          fi
+          repo="${IMAGE_REF%:*}"
+          size_bytes=$(docker buildx imagetools inspect "${repo}@${digest}" --raw \
+            | jq '[.layers[].size] | add')
+          size_mib=$(( size_bytes / 1024 / 1024 ))
+          max_mib=$(( MAX_IMAGE_SIZE_BYTES / 1024 / 1024 ))
+          echo "linux/amd64 compressed image size: ${size_mib} MiB (ceiling ${max_mib} MiB)"
+          if [ "$size_bytes" -gt "$MAX_IMAGE_SIZE_BYTES" ]; then
+            echo "::error::Image size ${size_mib} MiB exceeds the ${max_mib} MiB ceiling. Investigate dependency bloat before merging."
+            exit 1
+          fi
 
       - name: Smoke-test image
         run: |


### PR DESCRIPTION
## Summary

The Docker release workflow builds and pushes an image but doesn't enforce any size budget, so a careless `pip install` of a heavy transitive dep could silently double the published image before anyone notices. Per #42, the current image (`python:3.12-slim` + scherlok wheel + warehouse extras) sits at roughly 85-95 MiB, which leaves a small but real headroom against a 100 MiB ceiling. This PR adds that ceiling as a hard gate on the release publish.

The check resolves the `linux/amd64` manifest digest from the multi-arch index via `docker buildx imagetools inspect --raw` (the inspection-only path the issue suggested, no extra pull), sums the compressed layer sizes, and exits non-zero when the total exceeds `MAX_IMAGE_SIZE_BYTES`. The ceiling lives at workflow scope as a named env var with a short comment explaining intent so the threshold can be tuned later without touching the step body. The arm64 variant is deliberately out of scope for the first cut, matching the "amd64 is the simplest first cut" pointer in the issue.

## Why this matters

Tag pushes are the only place this workflow runs, so this is the last chance to catch bloat before a `vX.Y.Z` release lands on ghcr. Catching the regression in CI is significantly cheaper than discovering it after consumers pull the image and complain. A named env var keeps the ceiling adjustable as warehouse extras evolve, and the comment makes it clear why 100 MiB rather than a larger arbitrary number.

## Verification

YAML parses cleanly with `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/docker.yml'))"`. `jq` is preinstalled on `ubuntu-latest`, so no toolchain change is needed. The next `v*` tag push will exercise the new step in CI; against the current baseline the assertion will pass and emit the measured size in the workflow log, which doubles as a tracking signal over time.

Closes #42

AI disclosure: authored with Claude as a coding assistant; I reviewed the change before pushing.
