### PR TITLE
feat: add check command as alias for ci --fail-on critical

### DIFF
--- a/src/scherlok/cli.py
+++ b/src/scherlok/cli.py
@@ -337,6 +337,37 @@ def watch(
     raise typer.Exit(code=exit_code_for(anomalies))
 
 
+def _run_ci(
+    connection_string: str,
+    webhook: str | None,
+    email: list[str] | None,
+    fail_on: str,
+) -> None:
+    # Save connection
+    cfg = ScherlokConfig.load()
+    cfg.connection_string = connection_string
+    cfg.save()
+
+    # Validate connection
+    connector = get_connector(connection_string)
+    if not connector.connect():
+        _print_connect_failure(connector)
+        raise typer.Exit(code=1)
+
+    # Run watch (does profile + detect + alert in one)
+    anomalies = _run_watch(webhook=webhook, emails=email or None)
+
+    # Custom exit code based on --fail-on
+    fail_on_lower = fail_on.lower()
+    if fail_on_lower == "warning":
+        from scherlok.detector.severity import Severity
+        if any(a["severity"] in (Severity.WARNING, Severity.CRITICAL) for a in anomalies):
+            raise typer.Exit(code=1)
+    else:  # critical (default)
+        if exit_code_for(anomalies) == 1:
+            raise typer.Exit(code=1)
+
+
 @app.command()
 def ci(
     connection_string: str = typer.Argument(
@@ -365,29 +396,27 @@ def ci(
             scherlok config --store s3://my-bucket/scherlok/profiles.db
             scherlok ci $DATABASE_URL --webhook $SLACK_URL --fail-on critical
     """
-    # Save connection
-    cfg = ScherlokConfig.load()
-    cfg.connection_string = connection_string
-    cfg.save()
+    _run_ci(connection_string, webhook, email, fail_on)
 
-    # Validate connection
-    connector = get_connector(connection_string)
-    if not connector.connect():
-        _print_connect_failure(connector)
-        raise typer.Exit(code=1)
 
-    # Run watch (does profile + detect + alert in one)
-    anomalies = _run_watch(webhook=webhook, emails=email or None)
-
-    # Custom exit code based on --fail-on
-    fail_on_lower = fail_on.lower()
-    if fail_on_lower == "warning":
-        from scherlok.detector.severity import Severity
-        if any(a["severity"] in (Severity.WARNING, Severity.CRITICAL) for a in anomalies):
-            raise typer.Exit(code=1)
-    else:  # critical (default)
-        if exit_code_for(anomalies) == 1:
-            raise typer.Exit(code=1)
+@app.command()
+def check(
+    connection_string: str = typer.Argument(
+        ..., help="Database connection string"
+    ),
+    webhook: str = typer.Option(
+        None, "--webhook", "-w", help="Webhook URL for alerts"
+    ),
+    email: list[str] = typer.Option(
+        None, "--email", "-e", help="Email recipient(s) for alerts"
+    ),
+    fail_on: str = typer.Option(
+        "critical", "--fail-on",
+        help="Severity that triggers exit code 1: 'critical' (default) or 'warning'",
+    ),
+) -> None:
+    """Assertion-only CI alias for `scherlok ci --fail-on critical`."""
+    _run_ci(connection_string, webhook, email, fail_on)
 
 
 @app.command()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,7 @@ from typer.testing import CliRunner
 
 from scherlok.cli import app
 
-runner = CliRunner()
+runner = CliRunner(env={"NO_COLOR": "1"})
 
 
 def test_version_command():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,7 +19,7 @@ def test_help_shows_all_commands():
     """Test that help text lists all expected commands."""
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
-    for cmd in ["connect", "investigate", "watch", "report", "status", "version"]:
+    for cmd in ["connect", "investigate", "watch", "check", "report", "status", "version"]:
         assert cmd in result.output
 
 
@@ -101,6 +101,22 @@ def test_watch_help():
     """Test that watch command has help text."""
     result = runner.invoke(app, ["watch", "--help"])
     assert result.exit_code == 0
+
+
+def test_check_help():
+    """Test that check command has help text."""
+    result = runner.invoke(app, ["check", "--help"])
+    assert result.exit_code == 0
+
+
+def test_check_and_ci_share_options():
+    """Test that check and ci expose the same CI options."""
+    ci_help = runner.invoke(app, ["ci", "--help"]).output
+    check_help = runner.invoke(app, ["check", "--help"]).output
+
+    for option in ["--fail-on", "--webhook", "--email"]:
+        assert option in ci_help
+        assert option in check_help
 
 
 def test_report_help():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,17 @@
 """Tests for the Scherlok CLI."""
 
+import re
+
 from typer.testing import CliRunner
 
 from scherlok.cli import app
 
 runner = CliRunner(env={"NO_COLOR": "1"})
+
+# Rich emits bold/dim styling via ANSI even when NO_COLOR strips colors, and
+# CI runners typically have TERM=xterm so terminal-detection keeps styling on.
+# Strip before substring assertions on help output.
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
 
 def test_version_command():
@@ -111,8 +118,8 @@ def test_check_help():
 
 def test_check_and_ci_share_options():
     """Test that check and ci expose the same CI options."""
-    ci_help = runner.invoke(app, ["ci", "--help"]).output
-    check_help = runner.invoke(app, ["check", "--help"]).output
+    ci_help = ANSI_RE.sub("", runner.invoke(app, ["ci", "--help"]).output)
+    check_help = ANSI_RE.sub("", runner.invoke(app, ["check", "--help"]).output)
 
     for option in ["--fail-on", "--webhook", "--email"]:
         assert option in ci_help


### PR DESCRIPTION
## Summary

Add `scherlok check` as a thin Typer alias that delegates to the same code path as `scherlok ci --fail-on critical`. The motivation in #32: `ci` reads as "do everything", but most CI users want a focused assertion-only entry point. `check` keeps `ci` working unchanged for back-compat and shares the connector flow / store sync / alerters via a new private `_run_ci(...)` helper, so there is no code duplication.

## Why this matters

Issue #32 (filed by @rbmuller, the maintainer, 2026-05-07, labeled `enhancement` + `good first issue`) names the exact target file (`src/scherlok/cli.py`) and the recommended approach: extract the `ci` body into `_run_ci(...)` and have both `ci` and `check` delegate. The existing `ci(...)` body at `src/scherlok/cli.py:340-391` was four phases (save connection -> validate connector -> `_run_watch(...)` -> `--fail-on` exit code), each operating only on its parameters with no Typer request-context dependence — safe to lift verbatim into a helper.

The maintainer also points to docs/ROADMAP.md Month 6 ("more idiomatic alias for `ci --fail-on`") as the design intent, so `check` defaults `--fail-on` to `critical` and falls through to the same warning/critical branching `ci` already has.

## Testing

- `ruff check src/ tests/` — pass
- `pytest tests/test_cli.py -q` — 12 passed (was 10; the new tests cover help text, listing in `--help`, and option parity between `ci` and `check`)
- Manual: `scherlok check --help` lists `--fail-on`, `--webhook`, `--email`; `scherlok check $URL --fail-on warning` reaches the same branch as `scherlok ci --fail-on warning`

The acceptance criterion "test asserting both produce equivalent exit codes for the same fixture" is partially covered by the option-parity test plus shared `_run_ci(...)` body — both commands provably take the same code path for the same arguments. A live-database equivalence test isn't part of the existing `test_cli.py` shape (no live DB fixture there), so I followed the existing help/option pattern instead.

Closes #32
