### PR TITLE
docs(dbt): document dbt-run-and-watch in main + dbt README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ Use it as a CI gate after `dbt run`:
 - run: scherlok dbt --project-dir . --target prod --fail-on critical
 ```
 
+Or collapse both steps into one with the wrapper:
+
+```yaml
+- run: scherlok dbt-run-and-watch --project-dir . --target prod --fail-on critical
+```
+
 **Supported adapters:** `postgres`, `bigquery`, `snowflake`, `mysql`. For others, pass `--connection-string` explicitly.
 
 📖 Full docs: [dbt integration guide →](src/scherlok/dbt/README.md)

--- a/src/scherlok/dbt/README.md
+++ b/src/scherlok/dbt/README.md
@@ -74,12 +74,24 @@ Add Scherlok as a gate after `dbt run`:
 
 `--fail-on critical` exits with code 1 when any CRITICAL anomaly is detected; `--fail-on warning` is stricter and fails on WARNING+ as well.
 
-## What's coming next (Month 5)
+For CI parsers, pass `--output json` to emit a single JSON document on stdout (status + per-model anomalies) instead of the human-readable text.
+
+### One-shot wrapper: `scherlok dbt-run-and-watch`
+
+If your CI step is just `dbt run` then `scherlok dbt`, collapse them into one invocation:
+
+```yaml
+- run: |
+    pip install scherlok[dbt]
+    scherlok dbt-run-and-watch --project-dir . --target prod --fail-on critical
+```
+
+The wrapper streams `dbt run` output live. If `dbt run` exits non-zero, the wrapper propagates the exit code and skips the watch (a stale or partial manifest would surface noise, not signal). `--project-dir`, `--target`, `--profiles-dir`, and `--select` are forwarded to `dbt run`; everything else stays scherlok-only.
+
+## What's coming next
 
 - GitHub Action wrapper (`uses: rbmuller/scherlok-action@v1`)
-- `scherlok dbt run-and-watch` — runs `dbt run` and `scherlok dbt` in sequence
 - ASCII lineage tree from `manifest.parent_map` / `child_map`
-- JSON output for CI (`--output json`)
 
 ## Limitations of v0
 


### PR DESCRIPTION
## Summary

Post-#40 cleanup. The dbt README still listed \`scherlok dbt run-and-watch\` (wrong hyphenation) and \`--output json\` under "What's coming next" — both have shipped (#40 and #41 respectively). Moves them into the CI/CD usage section with runnable examples and trims the roadmap to items that are actually pending. Adds a one-line wrapper example to the main README's dbt section so the feature is discoverable from the top of the repo.

## Files

- \`README.md\` — adds a 4-line \`scherlok dbt-run-and-watch\` example right under the existing \`dbt run + scherlok dbt\` CI snippet.
- \`src/scherlok/dbt/README.md\` — adds an "One-shot wrapper" subsection under "CI/CD usage", documents \`--output json\`, removes both items from "coming next".

## Verification

- \`ruff check src tests\` clean
- \`pytest tests/\` 235 passed