### PR TITLE
feat(mcp): scherlok-mcp server — expose Scherlok to AI coding agents (#54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **MCP server** — `pip install scherlok[mcp]` adds a `scherlok-mcp` stdio server that exposes Scherlok to AI coding agents (Claude Code, Claude Desktop, …) as MCP tools: `list_tables`, `investigate`, `watch`, `status`, `history`, `check`. The connection is resolved server-side (`SCHERLOK_CONNECTION` / `scherlok config`) and never passed by the model; every operation is read-only on the warehouse with no arbitrary-SQL tool, and output is bounded. See [`src/scherlok/mcp/README.md`](src/scherlok/mcp/README.md). ([#54](https://github.com/rbmuller/scherlok/issues/54))
+
+### Changed
+- Extracted the per-table profile-and-detect orchestration into `scherlok.service` so the CLI and the new MCP server share one core (no behavior change).
+
 ## [0.6.0] — 2026-05-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -115,6 +115,29 @@ One self-contained HTML file (~28 KB): KPIs, per-table incidents grouped with fi
 
 📖 Full docs: [dashboard guide →](src/scherlok/dashboard/README.md)
 
+## Use it from an AI agent (MCP)
+
+Let Claude Code / Claude Desktop run data-quality checks directly:
+
+```bash
+pip install scherlok[mcp]
+```
+
+```json
+{
+  "mcpServers": {
+    "scherlok": {
+      "command": "scherlok-mcp",
+      "env": { "SCHERLOK_CONNECTION": "postgresql://user:pass@host/db" }
+    }
+  }
+}
+```
+
+The agent gets `list_tables`, `investigate`, `watch`, `status`, `history`, and `check` as tools. Credentials are resolved server-side (never passed by the model), every operation is read-only on the warehouse, and there's no arbitrary-SQL tool.
+
+📖 Full docs: [MCP server guide →](src/scherlok/mcp/README.md)
+
 ## How It Works
 
 ### 1. `investigate` — Learn the patterns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,12 @@ duckdb = [
 dbt = [
     "pyyaml>=6.0",
 ]
+mcp = [
+    "mcp>=1.2",
+]
 dev = [
     "duckdb>=0.9",
+    "mcp>=1.2",
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
     "ruff>=0.1.0",
@@ -55,6 +59,7 @@ dev = [
 
 [project.scripts]
 scherlok = "scherlok.cli:app"
+scherlok-mcp = "scherlok.mcp.server:main"
 
 [project.urls]
 Homepage = "https://github.com/rbmuller/scherlok"

--- a/src/scherlok/cli.py
+++ b/src/scherlok/cli.py
@@ -18,10 +18,7 @@ from scherlok.alerter.webhook import send_webhook
 from scherlok.config import ScherlokConfig
 from scherlok.connectors import get_connector
 from scherlok.detector.anomaly import detect_volume_anomalies
-from scherlok.detector.cardinality import detect_cardinality_anomalies
-from scherlok.detector.distribution_shift import detect_distribution_shift
 from scherlok.detector.freshness import detect_freshness_anomalies
-from scherlok.detector.nullability import detect_nullability_anomalies
 from scherlok.detector.schema_drift import detect_schema_drift
 from scherlok.output import error as out_error
 from scherlok.output import info as out_info
@@ -30,6 +27,7 @@ from scherlok.profiler.distribution import profile_distribution
 from scherlok.profiler.freshness import profile_freshness
 from scherlok.profiler.schema import profile_schema
 from scherlok.profiler.volume import profile_volume
+from scherlok.service import profile_and_detect
 from scherlok.store.remote import sync_context
 from scherlok.store.sqlite import ProfileStore
 
@@ -211,49 +209,11 @@ def investigate() -> None:
 def _watch_table(connector: object, store: ProfileStore, table: str) -> tuple[list[dict], dict]:
     """Profile one table + detect anomalies against stored baseline. Saves new profiles.
 
-    Returns (anomalies, current_volume) — `current_volume` is handy for callers
-    that want to display row counts inline (e.g. dbt-style ✓/✗ output).
+    Thin CLI-facing alias over `service.profile_and_detect` — kept so existing
+    call sites and tests that patch `scherlok.cli._watch_table` stay valid.
+    Returns (anomalies, current_volume).
     """
-    anomalies: list[dict] = []
-
-    current_vol = profile_volume(connector, table)
-    stored_vol = store.get_latest_profile(table, "volume")
-    if stored_vol:
-        anomalies.extend(detect_volume_anomalies(table, current_vol, stored_vol))
-
-    current_sch = profile_schema(connector, table)
-    stored_sch = store.get_latest_profile(table, "schema")
-    if stored_sch:
-        anomalies.extend(detect_schema_drift(table, current_sch, stored_sch))
-
-    current_fresh = profile_freshness(connector, table)
-    stored_fresh = store.get_latest_profile(table, "freshness")
-    if stored_fresh:
-        anomalies.extend(
-            detect_freshness_anomalies(table, current_fresh, stored_fresh)
-        )
-
-    for col in (current_sch or {}).get("columns", []):
-        col_name = col["name"]
-        current_dist = profile_distribution(connector, table, col_name)
-        stored_dist = store.get_latest_profile(table, f"distribution:{col_name}")
-        if stored_dist:
-            anomalies.extend(
-                detect_nullability_anomalies(table, col_name, current_dist, stored_dist)
-            )
-            anomalies.extend(
-                detect_distribution_shift(table, col_name, current_dist, stored_dist)
-            )
-            anomalies.extend(
-                detect_cardinality_anomalies(table, col_name, current_dist, stored_dist)
-            )
-        store.save_profile(table, f"distribution:{col_name}", current_dist)
-
-    store.save_profile(table, "volume", current_vol)
-    store.save_profile(table, "schema", current_sch)
-    store.save_profile(table, "freshness", current_fresh)
-
-    return anomalies, current_vol
+    return profile_and_detect(connector, store, table)
 
 
 def _dispatch_alerts(

--- a/src/scherlok/mcp/README.md
+++ b/src/scherlok/mcp/README.md
@@ -1,0 +1,94 @@
+# Scherlok MCP server
+
+Expose Scherlok's data-quality checks to an AI coding agent (Claude Code, Claude
+Desktop, Cursor, …) as [MCP](https://modelcontextprotocol.io) tools. The agent
+can profile your warehouse, detect anomalies, and gate on them — with structured
+results it reasons over, instead of shelling out and parsing text.
+
+## Install
+
+```bash
+pip install scherlok[mcp]
+```
+
+This adds the `mcp` SDK and the `scherlok-mcp` console script (a stdio server).
+
+## Configure the connection (server-side)
+
+The connection string is resolved **on the server**, never passed by the model.
+Set it once, either way:
+
+```bash
+# Option A — environment variable (per the MCP client config below)
+export SCHERLOK_CONNECTION="postgresql://user:pass@host:5432/db"
+
+# Option B — save it to ~/.scherlok/config.json
+scherlok connect "postgresql://user:pass@host:5432/db"
+```
+
+Any adapter Scherlok supports works: `postgresql://`, `bigquery://`,
+`snowflake://`, `mysql://`, `duckdb:///path/to/file.db`.
+
+## Wire it into your agent
+
+### Claude Desktop
+
+Add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "scherlok": {
+      "command": "scherlok-mcp",
+      "env": { "SCHERLOK_CONNECTION": "postgresql://user:pass@host:5432/db" }
+    }
+  }
+}
+```
+
+### Claude Code
+
+Either drop a project-scoped `.mcp.json` in your repo root:
+
+```json
+{
+  "mcpServers": {
+    "scherlok": {
+      "command": "scherlok-mcp",
+      "env": { "SCHERLOK_CONNECTION": "postgresql://user:pass@host:5432/db" }
+    }
+  }
+}
+```
+
+…or register it from the CLI:
+
+```bash
+claude mcp add scherlok --env SCHERLOK_CONNECTION="postgresql://..." -- scherlok-mcp
+```
+
+## Tools
+
+| Tool | Args | What it does |
+|------|------|--------------|
+| `list_tables` | — | tables visible to the connection |
+| `investigate` | `tables?` | profile tables, store the baseline |
+| `watch` | `tables?` | detect anomalies vs baseline (type/severity/message) |
+| `status` | — | connection (redacted), tables visible, anomalies in last 30 days |
+| `history` | `days?` | anomalies recorded in the last N days |
+| `check` | `fail_on?` | CI-style pass/fail gate (`critical` default, or `warning`) |
+
+Typical agent flow: `investigate` once to set the baseline, then `watch` (or
+`check`) on later runs to catch drift.
+
+## Security model
+
+- **Credentials never reach the model.** The connection string is read
+  server-side from `SCHERLOK_CONNECTION` / `scherlok config`. No tool accepts a
+  connection string as an argument.
+- **Read-only on the warehouse.** Every operation is `SELECT` /
+  `information_schema` only; Scherlok writes solely to its local profile store
+  (`~/.scherlok/profiles.db`). There is **no arbitrary-SQL tool** — the agent
+  can't run statements you didn't expose.
+- **Bounded output.** Tool results cap table and anomaly counts so a single
+  call can't blow the agent's context budget.

--- a/src/scherlok/mcp/__init__.py
+++ b/src/scherlok/mcp/__init__.py
@@ -1,0 +1,10 @@
+"""MCP server for Scherlok — exposes data-quality checks to AI coding agents.
+
+Install with `pip install scherlok[mcp]` and run via the `scherlok-mcp`
+console script. The connection is resolved server-side (env/config), never
+passed by the model. See `server.py` for the tool surface.
+"""
+
+from scherlok.mcp.server import build_server, main
+
+__all__ = ["build_server", "main"]

--- a/src/scherlok/mcp/server.py
+++ b/src/scherlok/mcp/server.py
@@ -1,0 +1,234 @@
+"""Scherlok MCP server.
+
+Exposes Scherlok's read-only data-quality operations as MCP tools so an AI
+coding agent (Claude Code, Claude Desktop, …) can profile a warehouse and
+detect anomalies directly, with structured results.
+
+Security model (see src/scherlok/mcp/README.md):
+  - The connection string is resolved server-side from `SCHERLOK_CONNECTION`
+    or `scherlok config`. It is never a tool argument — the model never sees
+    or supplies credentials.
+  - Every operation is read-only on the warehouse (SELECT / information_schema).
+    There is no arbitrary-SQL tool.
+  - Tool output is bounded so a single call can't exhaust the agent's context.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from scherlok.config import ENV_CONNECTION, ScherlokConfig
+from scherlok.connectors import get_connector
+from scherlok.connectors.base import BaseConnector
+from scherlok.service import anomaly_to_dict, profile_and_detect, redact_connection
+from scherlok.store.sqlite import ProfileStore
+
+SERVER_NAME = "scherlok"
+
+# Output caps — keep any single tool result within a sane token budget.
+MAX_TABLES = 1000
+MAX_ANOMALIES = 200
+
+
+class ConnectionNotConfiguredError(RuntimeError):
+    """Raised when no connection string is available server-side."""
+
+
+def _resolve_connection() -> str:
+    """Return the server-side connection string or raise a clear, actionable error."""
+    conn = ScherlokConfig.load().get_connection_string()
+    if not conn:
+        raise ConnectionNotConfiguredError(
+            f"No connection configured. Set the {ENV_CONNECTION} environment "
+            "variable on the MCP server, or run `scherlok connect <url>` once "
+            "to save it. The model never supplies the connection string."
+        )
+    return conn
+
+
+def _connect() -> BaseConnector:
+    """Open a connected connector from the server-side connection, or raise."""
+    connector = get_connector(_resolve_connection())
+    if not connector.connect():
+        err = getattr(connector, "last_error", None) or "unknown error"
+        raise ConnectionError(f"Failed to connect: {err}")
+    return connector
+
+
+def _select(tables: list[str] | None, visible: list[str]) -> list[str]:
+    """Resolve the requested table subset against what the connection can see.
+
+    Unknown names raise rather than silently profiling nothing, so the agent
+    gets told it asked for a table that isn't there.
+    """
+    if not tables:
+        return visible
+    visible_set = set(visible)
+    missing = [t for t in tables if t not in visible_set]
+    if missing:
+        raise ValueError(f"Tables not found on this connection: {missing}")
+    return tables
+
+
+# --------------------------------------------------------------------------
+# Tool implementations — plain functions so they're unit-testable without the
+# protocol layer. `build_server` registers them on a FastMCP instance.
+# --------------------------------------------------------------------------
+
+def list_tables() -> dict[str, Any]:
+    """List the tables visible to the configured warehouse connection.
+
+    Returns the table names (capped) and a total count. Use this to discover
+    what can be profiled before calling `investigate` or `watch`.
+    """
+    connector = _connect()
+    tables = connector.list_tables()
+    return {
+        "count": len(tables),
+        "tables": tables[:MAX_TABLES],
+        "truncated": len(tables) > MAX_TABLES,
+    }
+
+
+def investigate(tables: list[str] | None = None) -> dict[str, Any]:
+    """Profile tables and store them as the baseline for future anomaly checks.
+
+    Pass `tables` to limit to specific tables, or omit to profile everything
+    visible. The first profile of a table establishes its baseline; no
+    anomalies are reported here. Run `watch` later to detect drift.
+    """
+    connector = _connect()
+    targets = _select(tables, connector.list_tables())
+    store = ProfileStore()
+    try:
+        profiled = []
+        for table in targets:
+            _anomalies, vol = profile_and_detect(connector, store, table)
+            profiled.append({"table": table, "row_count": vol.get("row_count")})
+        return {"profiled": len(profiled), "tables": profiled}
+    finally:
+        store.close()
+
+
+def watch(tables: list[str] | None = None) -> dict[str, Any]:
+    """Profile tables and detect anomalies against the stored baseline.
+
+    Returns the anomalies found (type, severity, message per table), capped.
+    Pass `tables` to limit scope, or omit to watch everything. Tables with no
+    prior baseline are profiled silently (their baseline is set for next time).
+    """
+    connector = _connect()
+    targets = _select(tables, connector.list_tables())
+    store = ProfileStore()
+    try:
+        all_anomalies: list[dict] = []
+        for table in targets:
+            anomalies, _vol = profile_and_detect(connector, store, table)
+            all_anomalies.extend(anomalies)
+        if all_anomalies:
+            store.save_anomalies(all_anomalies)
+        critical = sum(1 for a in all_anomalies if "CRITICAL" in str(a.get("severity")))
+        warning = sum(1 for a in all_anomalies if "WARNING" in str(a.get("severity")))
+        return {
+            "tables_watched": len(targets),
+            "anomaly_count": len(all_anomalies),
+            "critical": critical,
+            "warning": warning,
+            "anomalies": [anomaly_to_dict(a) for a in all_anomalies[:MAX_ANOMALIES]],
+            "truncated": len(all_anomalies) > MAX_ANOMALIES,
+        }
+    finally:
+        store.close()
+
+
+def status() -> dict[str, Any]:
+    """Report the current monitoring state.
+
+    Returns the connection target (password redacted), how many tables the
+    connection can see, and how many anomalies were recorded in the last 30
+    days. A quick health glance without profiling anything.
+    """
+    connector = _connect()
+    store = ProfileStore()
+    try:
+        recent = store.get_anomaly_history(days=30)
+        return {
+            "connection": redact_connection(_resolve_connection()),
+            "tables_visible": len(connector.list_tables()),
+            "anomalies_last_30d": len(recent),
+        }
+    finally:
+        store.close()
+
+
+def history(days: int = 30) -> dict[str, Any]:
+    """Return anomalies recorded in the last `days` days (capped).
+
+    Reads from the local profile store — does not re-profile the warehouse.
+    """
+    store = ProfileStore()
+    try:
+        rows = store.get_anomaly_history(days=days)
+        return {
+            "days": days,
+            "count": len(rows),
+            "anomalies": [anomaly_to_dict(a) for a in rows[:MAX_ANOMALIES]],
+            "truncated": len(rows) > MAX_ANOMALIES,
+        }
+    finally:
+        store.close()
+
+
+def check(fail_on: str = "critical") -> dict[str, Any]:
+    """Run a watch over all tables and return a CI-style pass/fail gate.
+
+    `fail_on` is `"critical"` (default — fail only on CRITICAL) or `"warning"`
+    (stricter — fail on WARNING or worse). Mirrors `scherlok ci`. Returns
+    `passed` plus the severity counts the decision was based on.
+    """
+    threshold = fail_on.lower()
+    if threshold not in ("critical", "warning"):
+        raise ValueError("fail_on must be 'critical' or 'warning'")
+    result = watch(tables=None)
+    if threshold == "warning":
+        passed = result["critical"] == 0 and result["warning"] == 0
+    else:
+        passed = result["critical"] == 0
+    return {
+        "passed": passed,
+        "fail_on": threshold,
+        "critical": result["critical"],
+        "warning": result["warning"],
+    }
+
+
+_TOOLS = [list_tables, investigate, watch, status, history, check]
+
+
+def build_server() -> Any:
+    """Construct and return a FastMCP server with all tools registered.
+
+    Imported lazily so `pip install scherlok` (without the `[mcp]` extra)
+    doesn't error on a missing `mcp` dependency until the server is built.
+    """
+    try:
+        from mcp.server.fastmcp import FastMCP
+    except ImportError as exc:  # pragma: no cover - exercised via packaging
+        raise ImportError(
+            "The MCP server requires the 'mcp' package. "
+            "Install it with: pip install scherlok[mcp]"
+        ) from exc
+
+    server = FastMCP(SERVER_NAME)
+    for fn in _TOOLS:
+        server.tool()(fn)
+    return server
+
+
+def main() -> None:
+    """Console-script entry point: build the server and serve over stdio."""
+    build_server().run()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/scherlok/service.py
+++ b/src/scherlok/service.py
@@ -1,0 +1,113 @@
+"""Core profile-and-detect orchestration, shared by the CLI and the MCP server.
+
+This module is the single place that knows *how* to profile one table and
+detect anomalies against the stored baseline. Both adapters — the Typer CLI
+and the MCP server — call into here, so neither owns business logic the other
+can't reach. Nothing in this module prints, formats, or knows about a
+transport; it takes a connector + store and returns plain data.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+from scherlok.connectors.base import BaseConnector
+from scherlok.detector.anomaly import detect_volume_anomalies
+from scherlok.detector.cardinality import detect_cardinality_anomalies
+from scherlok.detector.distribution_shift import detect_distribution_shift
+from scherlok.detector.freshness import detect_freshness_anomalies
+from scherlok.detector.nullability import detect_nullability_anomalies
+from scherlok.detector.schema_drift import detect_schema_drift
+from scherlok.profiler.distribution import profile_distribution
+from scherlok.profiler.freshness import profile_freshness
+from scherlok.profiler.schema import profile_schema
+from scherlok.profiler.volume import profile_volume
+from scherlok.store.sqlite import ProfileStore
+
+
+def profile_and_detect(
+    connector: BaseConnector, store: ProfileStore, table: str
+) -> tuple[list[dict], dict]:
+    """Profile one table, detect anomalies against the stored baseline, save profiles.
+
+    Returns ``(anomalies, current_volume)``. ``current_volume`` is returned
+    separately because callers often want the row count inline (e.g. the CLI's
+    dbt-style ✓/✗ line) without digging through the saved profile.
+
+    The first time a table is seen there is no baseline, so no anomalies fire —
+    the profiles saved on this run become the baseline for the next one.
+    """
+    anomalies: list[dict] = []
+
+    current_vol = profile_volume(connector, table)
+    stored_vol = store.get_latest_profile(table, "volume")
+    if stored_vol:
+        anomalies.extend(detect_volume_anomalies(table, current_vol, stored_vol))
+
+    current_sch = profile_schema(connector, table)
+    stored_sch = store.get_latest_profile(table, "schema")
+    if stored_sch:
+        anomalies.extend(detect_schema_drift(table, current_sch, stored_sch))
+
+    current_fresh = profile_freshness(connector, table)
+    stored_fresh = store.get_latest_profile(table, "freshness")
+    if stored_fresh:
+        anomalies.extend(detect_freshness_anomalies(table, current_fresh, stored_fresh))
+
+    for col in (current_sch or {}).get("columns", []):
+        col_name = col["name"]
+        current_dist = profile_distribution(connector, table, col_name)
+        stored_dist = store.get_latest_profile(table, f"distribution:{col_name}")
+        if stored_dist:
+            anomalies.extend(
+                detect_nullability_anomalies(table, col_name, current_dist, stored_dist)
+            )
+            anomalies.extend(
+                detect_distribution_shift(table, col_name, current_dist, stored_dist)
+            )
+            anomalies.extend(
+                detect_cardinality_anomalies(table, col_name, current_dist, stored_dist)
+            )
+        store.save_profile(table, f"distribution:{col_name}", current_dist)
+
+    store.save_profile(table, "volume", current_vol)
+    store.save_profile(table, "schema", current_sch)
+    store.save_profile(table, "freshness", current_fresh)
+
+    return anomalies, current_vol
+
+
+def redact_connection(connection_string: str) -> str:
+    """Mask the password in a connection string for safe display.
+
+    ``postgresql://alice:secret@host/db`` -> ``postgresql://alice:***@host/db``.
+    Returns the input unchanged when there's no password to hide.
+    """
+    if not connection_string:
+        return connection_string
+    parts = urlsplit(connection_string)
+    if not parts.password:
+        return connection_string
+    host = parts.hostname or ""
+    if parts.port:
+        host = f"{host}:{parts.port}"
+    userinfo = f"{parts.username}:***" if parts.username else "***"
+    return urlunsplit(
+        (parts.scheme, f"{userinfo}@{host}", parts.path, parts.query, parts.fragment)
+    )
+
+
+def anomaly_to_dict(anomaly: dict) -> dict[str, Any]:
+    """Normalize one anomaly into a JSON-safe dict for structured transports.
+
+    The detector layer stores ``severity`` as a ``Severity`` enum; serialize it
+    to its bare name (``"CRITICAL"``) so MCP/JSON consumers get a stable string
+    rather than ``"Severity.CRITICAL"``.
+    """
+    return {
+        "table": anomaly.get("table"),
+        "type": anomaly.get("type"),
+        "severity": str(anomaly.get("severity", "")).rsplit(".", 1)[-1],
+        "message": anomaly.get("message"),
+    }

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,174 @@
+"""Tests for the Scherlok MCP server.
+
+Strategy: drive the tools end-to-end against a real in-memory DuckDB
+connection (shared across calls via a patched `get_connector`) so the
+profile→detect→store wiring is exercised for real, not mocked. The protocol
+layer is smoke-tested by building the FastMCP server and listing its tools.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+
+import pytest
+
+_HAS_DUCKDB = importlib.util.find_spec("duckdb") is not None
+_HAS_MCP = importlib.util.find_spec("mcp") is not None
+
+pytestmark = pytest.mark.skipif(not _HAS_DUCKDB, reason="duckdb not installed")
+
+
+@pytest.fixture()
+def duck_connector():
+    """A connected in-memory DuckDB connector with two seeded tables."""
+    from scherlok.connectors.duckdb import DuckDBConnector
+
+    conn = DuckDBConnector("duckdb:///:memory:")
+    assert conn.connect() is True
+    conn._conn.execute("CREATE TABLE orders (id INTEGER, amount DOUBLE)")
+    conn._conn.execute("INSERT INTO orders VALUES (1, 10.0), (2, 20.0), (3, 30.0)")
+    conn._conn.execute("CREATE TABLE users (id INTEGER, email VARCHAR)")
+    conn._conn.execute("INSERT INTO users VALUES (1, 'a@x.com'), (2, 'b@x.com')")
+    return conn
+
+
+@pytest.fixture()
+def wired(monkeypatch, tmp_path, duck_connector):
+    """Point the server at the shared connector + an isolated profile store."""
+    from scherlok import mcp as mcp_pkg  # noqa: F401
+    from scherlok.mcp import server
+
+    monkeypatch.setenv("SCHERLOK_CONNECTION", "duckdb:///:memory:")
+    monkeypatch.setattr(server, "get_connector", lambda _cs: duck_connector)
+    monkeypatch.setattr("scherlok.store.sqlite.PROFILES_DB", tmp_path / "profiles.db")
+    # The tool's _connect() calls connect() again; on a :memory: DuckDB that
+    # would replace the connection with a fresh empty DB and wipe the seeded
+    # tables. The connector is already connected, so make re-connect a no-op.
+    monkeypatch.setattr(duck_connector, "connect", lambda: True)
+    return server
+
+
+# ----- connection resolution ------------------------------------------------
+
+def test_resolve_connection_raises_when_unset(monkeypatch):
+    from scherlok.mcp import server
+
+    monkeypatch.delenv("SCHERLOK_CONNECTION", raising=False)
+    monkeypatch.setattr(
+        "scherlok.config.ScherlokConfig.get_connection_string", lambda self: ""
+    )
+    with pytest.raises(server.ConnectionNotConfiguredError):
+        server._resolve_connection()
+
+
+# ----- list_tables ----------------------------------------------------------
+
+def test_list_tables(wired):
+    out = wired.list_tables()
+    assert out["count"] == 2
+    assert set(out["tables"]) == {"orders", "users"}
+    assert out["truncated"] is False
+
+
+# ----- investigate ----------------------------------------------------------
+
+def test_investigate_all(wired):
+    out = wired.investigate()
+    assert out["profiled"] == 2
+    rows = {t["table"]: t["row_count"] for t in out["tables"]}
+    assert rows["orders"] == 3
+    assert rows["users"] == 2
+
+
+def test_investigate_subset(wired):
+    out = wired.investigate(tables=["orders"])
+    assert out["profiled"] == 1
+    assert out["tables"][0]["table"] == "orders"
+
+
+def test_investigate_unknown_table_raises(wired):
+    with pytest.raises(ValueError, match="not found"):
+        wired.investigate(tables=["ghost"])
+
+
+# ----- watch ----------------------------------------------------------------
+
+def test_watch_first_run_no_anomalies(wired):
+    # First sighting establishes the baseline — nothing to compare against yet.
+    out = wired.watch()
+    assert out["anomaly_count"] == 0
+    assert out["critical"] == 0
+    assert out["tables_watched"] == 2
+
+
+def test_watch_detects_volume_drop_end_to_end(wired, duck_connector):
+    # Baseline, then delete most rows so the next watch sees a volume drop.
+    wired.investigate(tables=["orders"])
+    duck_connector._conn.execute("DELETE FROM orders WHERE id > 1")  # 3 -> 1 row
+
+    out = wired.watch(tables=["orders"])
+
+    assert out["anomaly_count"] >= 1
+    assert out["critical"] >= 1
+    a = out["anomalies"][0]
+    assert a["table"] == "orders"
+    assert a["severity"] == "CRITICAL"  # serialized to bare name, not "Severity.CRITICAL"
+    assert "type" in a and "message" in a
+
+
+# ----- status ---------------------------------------------------------------
+
+def test_status_redacts_and_counts(wired, monkeypatch):
+    monkeypatch.setenv("SCHERLOK_CONNECTION", "postgresql://alice:secret@h/db")
+    out = wired.status()
+    assert "secret" not in out["connection"]
+    assert "***" in out["connection"]
+    assert out["tables_visible"] == 2
+    assert out["anomalies_last_30d"] == 0
+
+
+# ----- history --------------------------------------------------------------
+
+def test_history_reads_store(wired, duck_connector):
+    wired.investigate(tables=["orders"])
+    duck_connector._conn.execute("DELETE FROM orders WHERE id > 1")
+    wired.watch(tables=["orders"])  # persists anomalies
+
+    out = wired.history(days=30)
+    assert out["count"] >= 1
+    assert out["days"] == 30
+    assert all("severity" in a for a in out["anomalies"])
+
+
+# ----- check ----------------------------------------------------------------
+
+def test_check_passes_when_clean(wired):
+    out = wired.check()
+    assert out["passed"] is True
+    assert out["critical"] == 0
+
+
+def test_check_fails_on_critical(wired, duck_connector):
+    wired.investigate()
+    duck_connector._conn.execute("DELETE FROM orders WHERE id > 1")
+    out = wired.check(fail_on="critical")
+    assert out["passed"] is False
+    assert out["critical"] >= 1
+
+
+def test_check_invalid_fail_on_raises(wired):
+    with pytest.raises(ValueError, match="critical.*warning|fail_on"):
+        wired.check(fail_on="banana")
+
+
+# ----- protocol smoke test --------------------------------------------------
+
+@pytest.mark.skipif(not _HAS_MCP, reason="mcp not installed")
+def test_build_server_registers_all_tools():
+    from scherlok.mcp.server import build_server
+
+    server = build_server()
+    tools = asyncio.run(server.list_tools())
+    names = {t.name for t in tools}
+    assert names == {"list_tables", "investigate", "watch", "status", "history", "check"}


### PR DESCRIPTION
Closes #54.

## Summary

Adds an MCP server so AI coding agents (Claude Code, Claude Desktop, Cursor, …) can run Scherlok's data-quality checks **as tools**, with structured results — the most direct, legitimate path to "an agent uses Scherlok".

## Architecture

- **Service layer first.** Extracted the per-table profile-and-detect orchestration from `cli._watch_table` into a transport-agnostic `scherlok.service`. The CLI and the MCP server are now both thin adapters over one core; `cli._watch_table` delegates to `service.profile_and_detect` (no behavior change).
- **`scherlok.mcp.server`** built on `FastMCP`, exposing six read-only tools: `list_tables`, `investigate`, `watch`, `status`, `history`, `check`.
- **Packaging:** `pip install scherlok[mcp]` + a `scherlok-mcp` console script (stdio transport).

## Security model

- **Credentials never reach the model** — connection resolved server-side from `SCHERLOK_CONNECTION` / `scherlok config`, never a tool argument.
- **Read-only on the warehouse** — `SELECT` / `information_schema` only; no arbitrary-SQL tool.
- **Bounded output** — `MAX_TABLES` / `MAX_ANOMALIES` caps so a call can't blow the agent's context.

## Tests

- 13 MCP tests driving the tools end-to-end against a **real in-memory DuckDB** connection, including a baseline → mutate → `watch` volume-drop detection and password redaction in `status`.
- Protocol smoke test asserts all six tools register on the `FastMCP` server.
- `mcp>=1.2` added to the `dev` extra so these run on CI.

## Files

- `src/scherlok/service.py` (new) — shared core + `redact_connection`, `anomaly_to_dict`
- `src/scherlok/mcp/{__init__,server}.py` (new)
- `src/scherlok/mcp/README.md` (new) — install, Claude Desktop/Code config, tool table, security note
- `src/scherlok/cli.py` — `_watch_table` delegates to the service
- `pyproject.toml` — `[mcp]` extra, `scherlok-mcp` entry point, `mcp` in `dev`
- `tests/test_mcp_server.py` (new), `README.md`, `CHANGELOG.md`

## Verification

```
ruff check src tests   # clean
pytest tests/          # 285 passed
scherlok-mcp           # entry point installed; build_server() lists 6 tools
```

## Out of scope (follow-ups)

`dbt_watch` MCP tool, HTTP/SSE transport, MCP resources/prompts, registry publishing.