### PR TITLE
chore(mcp): server.json + PyPI ownership marker for MCP Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- mcp-name: io.github.rbmuller/scherlok -->
 <div align="center">
 
 <img src="https://img.shields.io/badge/python-3.10+-blue?logo=python&logoColor=white" alt="Python 3.10+">

--- a/server.json
+++ b/server.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.rbmuller/scherlok",
+  "title": "Scherlok",
+  "description": "Zero-config data quality monitoring as MCP tools. Profile a warehouse, detect anomalies (volume / schema / freshness / NULL / distribution / cardinality), and gate CI — all read-only, credentials resolved server-side.",
+  "repository": {
+    "url": "https://github.com/rbmuller/scherlok",
+    "source": "github"
+  },
+  "version": "0.7.0",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "scherlok",
+      "version": "0.7.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "SCHERLOK_CONNECTION",
+          "description": "Warehouse connection string (postgresql://, bigquery://, snowflake://, mysql://, duckdb:///path). Resolved server-side; never passed by the model.",
+          "isRequired": true,
+          "isSecret": true,
+          "format": "string"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Prep work to publish \`scherlok-mcp\` to the [official MCP Registry](https://registry.modelcontextprotocol.io). The registry hosts metadata only and verifies that the underlying PyPI package matches.

## What's in this PR

- **\`README.md\`** — add the line \`<!-- mcp-name: io.github.rbmuller/scherlok -->\` at the very top. PyPI's long_description is built from README; the registry's PyPI verifier reads this marker. It's an HTML comment so it doesn't affect what readers see on GitHub or PyPI.
- **\`server.json\`** at the repo root — registry manifest:
  - \`name: io.github.rbmuller/scherlok\`
  - \`registryType: pypi\`, \`identifier: scherlok\`, \`version: 0.7.0\`
  - \`transport: stdio\`
  - \`SCHERLOK_CONNECTION\` declared as required + secret env var

## Open design question — needs your call

The registry installs the package's bare identifier: \`pip install scherlok\`. That **doesn't** pull the \`[mcp]\` extra, so \`scherlok-mcp\` would fail at startup on the missing \`mcp\` SDK. Three paths:

| Path | Pro | Con |
|---|---|---|
| **(a) Move \`mcp>=1.2\` to core deps** *(recommended)* | Registry "just works" — agent installs \`scherlok\` and runs \`scherlok-mcp\`. | Every \`pip install scherlok\` pulls \`mcp\` (+ anyio/pydantic/httpx). Moderate weight. |
| (b) Publish a separate \`scherlok-mcp\` PyPI package | Cleanest separation; bare \`scherlok\` stays lean. | Second package to maintain/release; \`server.json identifier\` switches to \`scherlok-mcp\`. |
| (c) Keep extra, document it | Zero churn. | Breaks the registry's auto-install path — \`scherlok-mcp\` errors after install. |

My read: **(a)** for v0 of registry presence — pragmatic, single-package release flow, no real bloat. If install size becomes a complaint later, split (b) cleanly.

## What this PR does NOT do (and can't do without you)

1. **Cut the v0.7.0 release.** The marker has to be in the *published* PyPI release, so this lands first → release follows.
2. **\`mcp-publisher login github\` + \`publish\`.** Both are interactive: the login is GitHub device-code auth on your account; the publish is an external write to the registry. Has to be you, by hand.

## After merge, the sequence

1. Decide (a)/(b)/(c) — I open a follow-up PR for the dep move if (a).
2. Cut v0.7.0 (CHANGELOG + version bump + tag → PyPI publish via the existing release workflow).
3. \`brew install mcp-publisher\` (or pre-built binary).
4. \`mcp-publisher login github\` (your auth).
5. \`mcp-publisher publish\` from the repo root — picks up \`server.json\`.
6. Verify: \`curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.rbmuller/scherlok"\`.

Sources: [PyPI verification](https://modelcontextprotocol.io/registry/package-types#pypi-packages), [publish quickstart](https://modelcontextprotocol.io/registry/quickstart).