### PR TITLE
chore(release): v0.7.0

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,11 +16,13 @@ permissions:
   contents: read
 
 # Catch dependency bloat early: if a new transitive dep silently doubles the
-# image, fail the publish before a release tag goes out. The current image
-# (python:3.12-slim + scherlok wheel + warehouse extras) sits ~85-95 MiB, so
-# 100 MiB is a small headroom and not a stretch target.
+# image, fail the publish before a release tag goes out. v0.7.0 added the
+# `mcp` core dep (pydantic, anyio, httpx, starlette, uvicorn family) which
+# lifts the baseline ~5-10 MiB above v0.6.0's 85-95 MiB; the cap was bumped
+# to 130 MiB to keep the same "small headroom" framing without false-failing
+# the legitimate growth.
 env:
-  MAX_IMAGE_SIZE_BYTES: 104857600
+  MAX_IMAGE_SIZE_BYTES: 136314880
 
 jobs:
   build-and-push:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] — 2026-05-28
+
 ### Added
-- **MCP server** — `pip install scherlok[mcp]` adds a `scherlok-mcp` stdio server that exposes Scherlok to AI coding agents (Claude Code, Claude Desktop, …) as MCP tools: `list_tables`, `investigate`, `watch`, `status`, `history`, `check`. The connection is resolved server-side (`SCHERLOK_CONNECTION` / `scherlok config`) and never passed by the model; every operation is read-only on the warehouse with no arbitrary-SQL tool, and output is bounded. See [`src/scherlok/mcp/README.md`](src/scherlok/mcp/README.md). ([#54](https://github.com/rbmuller/scherlok/issues/54))
+- **MCP server** — `pip install scherlok` now ships a `scherlok-mcp` stdio server that exposes Scherlok to AI coding agents (Claude Code, Claude Desktop, …) as MCP tools: `list_tables`, `investigate`, `watch`, `status`, `history`, `check`. The connection is resolved server-side (`SCHERLOK_CONNECTION` / `scherlok config`) and never passed by the model; every operation is read-only on the warehouse with no arbitrary-SQL tool, and output is bounded. See [`src/scherlok/mcp/README.md`](src/scherlok/mcp/README.md). ([#54](https://github.com/rbmuller/scherlok/issues/54), [#55](https://github.com/rbmuller/scherlok/pull/55))
+- **`server.json` + PyPI ownership marker** — repo-root `server.json` and an `mcp-name: io.github.rbmuller/scherlok` marker in the README so Scherlok can be published to the official MCP Registry (registry.modelcontextprotocol.io). ([#56](https://github.com/rbmuller/scherlok/pull/56))
 
 ### Changed
-- Extracted the per-table profile-and-detect orchestration into `scherlok.service` so the CLI and the new MCP server share one core (no behavior change).
+- **`mcp` is now a core dependency** (moved out of the `[mcp]` extra) so the registry's `pip install scherlok` install path produces a working `scherlok-mcp` without an extra step. The `[mcp]` extra is kept as a back-compat alias and still resolves cleanly. This adds ~15 transitive packages (anyio, pydantic, httpx, starlette, uvicorn family) to the base install; the trade was deliberate — first-class agent integration over a lean install.
+- Extracted the per-table profile-and-detect orchestration into `scherlok.service` so the CLI and the MCP server share one transport-agnostic core (no behavior change).
 
 ## [0.6.0] — 2026-05-20
 
@@ -110,7 +114,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Slack webhook integration
 - 59 unit tests
 
-[Unreleased]: https://github.com/rbmuller/scherlok/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/rbmuller/scherlok/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/rbmuller/scherlok/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/rbmuller/scherlok/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/rbmuller/scherlok/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/rbmuller/scherlok/compare/v0.3.0...v0.4.0

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ One self-contained HTML file (~28 KB): KPIs, per-table incidents grouped with fi
 Let Claude Code / Claude Desktop run data-quality checks directly:
 
 ```bash
-pip install scherlok[mcp]
+pip install scherlok   # scherlok-mcp ships built-in since v0.7.0
 ```
 
 ```json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scherlok"
-version = "0.6.0"
+version = "0.7.0"
 description = "A detective for your data. Zero-config data quality monitoring."
 readme = "README.md"
 license = "MIT"
@@ -27,6 +27,7 @@ dependencies = [
     "psycopg2-binary>=2.9.0",
     "requests>=2.28.0",
     "jinja2>=3.0",
+    "mcp>=1.2",
 ]
 
 [project.optional-dependencies]

--- a/src/scherlok/__init__.py
+++ b/src/scherlok/__init__.py
@@ -1,3 +1,3 @@
 """Scherlok — A detective for your data. Zero-config data quality monitoring."""
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"

--- a/src/scherlok/mcp/README.md
+++ b/src/scherlok/mcp/README.md
@@ -8,10 +8,10 @@ results it reasons over, instead of shelling out and parsing text.
 ## Install
 
 ```bash
-pip install scherlok[mcp]
+pip install scherlok
 ```
 
-This adds the `mcp` SDK and the `scherlok-mcp` console script (a stdio server).
+The MCP server ships built-in since v0.7.0 — the `scherlok-mcp` console script (a stdio server) is installed alongside the `scherlok` CLI. (The legacy `pip install scherlok[mcp]` still works as a back-compat alias.)
 
 ## Configure the connection (server-side)
 

--- a/src/scherlok/mcp/__init__.py
+++ b/src/scherlok/mcp/__init__.py
@@ -1,8 +1,9 @@
 """MCP server for Scherlok — exposes data-quality checks to AI coding agents.
 
-Install with `pip install scherlok[mcp]` and run via the `scherlok-mcp`
-console script. The connection is resolved server-side (env/config), never
-passed by the model. See `server.py` for the tool surface.
+Ships built-in since v0.7.0: `pip install scherlok` installs the `scherlok-mcp`
+console script alongside the `scherlok` CLI. The connection is resolved
+server-side (env/config), never passed by the model. See `server.py` for the
+tool surface.
 """
 
 from scherlok.mcp.server import build_server, main

--- a/src/scherlok/mcp/server.py
+++ b/src/scherlok/mcp/server.py
@@ -215,8 +215,9 @@ def build_server() -> Any:
         from mcp.server.fastmcp import FastMCP
     except ImportError as exc:  # pragma: no cover - exercised via packaging
         raise ImportError(
-            "The MCP server requires the 'mcp' package. "
-            "Install it with: pip install scherlok[mcp]"
+            "The MCP server requires the 'mcp' package, which ships with "
+            "scherlok by default. Re-install scherlok to pull it in: "
+            "pip install --upgrade scherlok"
         ) from exc
 
     server = FastMCP(SERVER_NAME)


### PR DESCRIPTION
Cuts **v0.7.0** — the MCP release.

## What's in it (since v0.6.0)

- **MCP server** (#54, #55) — \`scherlok-mcp\` stdio server exposing six read-only tools (\`list_tables\`, \`investigate\`, \`watch\`, \`status\`, \`history\`, \`check\`) to AI coding agents. Connection resolved server-side, no arbitrary-SQL, output bounded.
- **MCP Registry prep** (#56) — repo-root \`server.json\` + \`mcp-name\` PyPI ownership marker in the README so this release can be submitted to registry.modelcontextprotocol.io.

## This PR

- Bumps \`version\` 0.6.0 → 0.7.0 in \`pyproject.toml\` and \`src/scherlok/__init__.py\`
- **Moves \`mcp>=1.2\` from the \`[mcp]\` extra into core dependencies** so the registry's \`pip install scherlok\` path produces a working \`scherlok-mcp\` without the user knowing about an extra. The \`[mcp]\` extra is kept as a back-compat alias. Trade-off documented: adds ~15 transitive packages (anyio, pydantic, httpx, starlette family) to the base install — accepted for first-class agent integration.
- Docs (\`README\`, \`mcp/README\`) switched to the short \`pip install scherlok\` form, with a note that the MCP server ships built-in since 0.7.0.
- Cuts the \`[0.7.0]\` CHANGELOG section and fixes the footer compare links.

## Release process after merge

Tagging \`v0.7.0\` on \`main\` triggers \`release.yml\`: test → PyPI publish (trusted publishing) → GitHub Release with notes auto-extracted from this CHANGELOG section.

## After release: MCP Registry submission (your hands)

1. \`brew install mcp-publisher\` (or the pre-built binary)
2. \`mcp-publisher login github\` — interactive device-code auth on your GitHub account
3. \`mcp-publisher publish\` from the repo root — picks up \`server.json\`
4. Verify: \`curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.rbmuller/scherlok"\`

## Verification

- \`ruff check src tests\` clean
- \`pytest tests/\` — 285 passed
- Version sync confirmed: \`scherlok.__version__ == pyproject version == 0.7.0\`