### PR TITLE
docs+refactor: clarify distribution-shift detection tiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Three commands. Five minutes. Done.
 | **Freshness alert** | Table hasn't updated in 12h (normally every 2h) | CRITICAL |
 | **Schema drift** | Column removed or type changed | CRITICAL |
 | **NULL surge** | NULL rate jumped from 2% to 45% | WARNING |
-| **Distribution shift** | Column mean shifted 5+ standard deviations | WARNING |
+| **Distribution shift** | Column mean shifted 3+ standard deviations (Shewhart-style control limit) | INFO, WARNING above 5σ |
 | **Cardinality explosion** | Status column went from 5 values to 500 | CRITICAL |
 
 Every anomaly is auto-scored: **INFO**, **WARNING**, or **CRITICAL**. No thresholds to configure.

--- a/src/scherlok/detector/severity.py
+++ b/src/scherlok/detector/severity.py
@@ -37,10 +37,13 @@ def classify_freshness_miss() -> Severity:
 
 
 def classify_distribution_shift(z_score: float) -> Severity:
-    """Classify distribution shift based on z-score magnitude."""
-    abs_z = abs(z_score)
-    if abs_z > 5:
+    """Classify distribution shift based on z-score magnitude.
+
+    Detection starts at |z| > 3 (the classic Shewhart control limit,
+    enforced by the detector); 3-5 sigma classifies as INFO, beyond 5
+    sigma as WARNING. Deliberately never CRITICAL: a mean shift is a
+    symptom for a human to judge, not a CI-blocking failure on its own.
+    """
+    if abs(z_score) > 5:
         return Severity.WARNING
-    if abs_z > 3:
-        return Severity.INFO
     return Severity.INFO

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -146,6 +146,14 @@ class TestSeverityClassification:
     def test_distribution_shift_info(self):
         assert classify_distribution_shift(3.5) == Severity.INFO
 
+    def test_distribution_shift_negative_z_symmetric(self):
+        assert classify_distribution_shift(-6.0) == Severity.WARNING
+        assert classify_distribution_shift(-3.5) == Severity.INFO
+
+    def test_distribution_shift_never_critical(self):
+        """A mean shift alone must not gate CI — pinned by design."""
+        assert classify_distribution_shift(50.0) != Severity.CRITICAL
+
 
 class TestFreshnessDetector:
     """Tests for freshness anomaly detection."""


### PR DESCRIPTION
Prompted by a sharp reader question on LinkedIn about the 5σ threshold in the README.

## What

- **README**: the anomaly table said *"mean shifted 5+ standard deviations"*, but detection actually starts at **|z| > 3** (the classic Shewhart control limit) — 5σ is the WARNING escalation tier, not the detection gate. The table now states both, matching the console example a few sections below (which already showed a 3.2σ INFO).
- **`classify_distribution_shift`**: removed the dead 3σ branch (both paths returned INFO) and documented the tiers in the docstring — including that the function deliberately never returns CRITICAL (a mean shift is a symptom for a human to judge, not a CI-blocking failure on its own). Behavior unchanged.
- **Tests**: pinned negative-z symmetry and the never-CRITICAL contract.

## How to test

```bash
ruff check src/ tests/ && pytest tests/  # 342 passed
```