### PR TITLE
fix: include views in MySQL and DuckDB list_tables

### DIFF
--- a/src/scherlok/connectors/duckdb.py
+++ b/src/scherlok/connectors/duckdb.py
@@ -63,10 +63,10 @@ class DuckDBConnector(BaseConnector):
         return f'"{identifier.replace(chr(34), chr(34) * 2)}"'
 
     def list_tables(self) -> list[str]:
-        """List all base tables in the main schema."""
+        """List all tables and views in the main schema."""
         rows = self._conn.execute(
             "SELECT table_name FROM information_schema.tables "
-            "WHERE table_schema = 'main' AND table_type = 'BASE TABLE' "
+            "WHERE table_schema = 'main' AND table_type IN ('BASE TABLE', 'VIEW') "
             "ORDER BY table_name"
         ).fetchall()
         return [row[0] for row in rows]

--- a/src/scherlok/connectors/mysql.py
+++ b/src/scherlok/connectors/mysql.py
@@ -70,12 +70,12 @@ class MySQLConnector(BaseConnector):
         return self._conn.cursor()
 
     def list_tables(self) -> list[str]:
-        """List all base tables in the current database."""
+        """List all tables and views in the current database."""
         db = urlparse(self.connection_string).path.lstrip("/")
         with self._cursor() as cur:
             cur.execute(
                 "SELECT TABLE_NAME FROM information_schema.TABLES "
-                "WHERE TABLE_SCHEMA = %s AND TABLE_TYPE = 'BASE TABLE' "
+                "WHERE TABLE_SCHEMA = %s AND TABLE_TYPE IN ('BASE TABLE', 'VIEW') "
                 "ORDER BY TABLE_NAME",
                 (db,),
             )

--- a/tests/test_duckdb.py
+++ b/tests/test_duckdb.py
@@ -76,6 +76,13 @@ def test_list_tables(connector):
     assert connector.list_tables() == ["orders", "users"]
 
 
+def test_list_tables_includes_created_view(connector):
+    connector._conn.execute("CREATE TABLE users (id INTEGER)")
+    connector._conn.execute("CREATE VIEW active_users AS SELECT * FROM users")
+
+    assert connector.list_tables() == ["active_users", "users"]
+
+
 def test_get_row_count(connector):
     connector._conn.execute("CREATE TABLE orders (id INTEGER)")
     connector._conn.execute("INSERT INTO orders VALUES (1), (2), (3)")

--- a/tests/test_mysql.py
+++ b/tests/test_mysql.py
@@ -112,6 +112,22 @@ def test_list_tables(connector):
     assert "TABLE_TYPE" in sql
 
 
+def test_list_tables_includes_view_rows_from_mocked_information_schema(connector):
+    c, fake_conn = connector
+    _wire_cursor(fake_conn, fetchall=[
+        {"TABLE_NAME": "active_users", "TABLE_TYPE": "VIEW"},
+        {"TABLE_NAME": "users", "TABLE_TYPE": "BASE TABLE"},
+    ])
+
+    assert c.list_tables() == ["active_users", "users"]
+
+    execute_call = fake_conn.cursor().__enter__().execute.call_args
+    sql, params = execute_call.args
+    assert "'BASE TABLE'" in sql
+    assert "'VIEW'" in sql
+    assert params == ("testdb",)
+
+
 # ---------------------------------------------------------------------------
 # Test 4 — get_row_count issues COUNT(*) and returns integer
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- include `VIEW` alongside `BASE TABLE` in MySQL table discovery
- include `VIEW` alongside `BASE TABLE` in DuckDB table discovery
- add mocked MySQL and real in-memory DuckDB regression coverage
- preserve existing base-table discovery and ordering

## Testing

- `ruff check src/ tests/`
- `pytest tests/test_mysql.py tests/test_duckdb.py -v`
- `pytest tests/ -v`
- `git diff --check`

Closes #51
