### PR TITLE
feat(dbt): support JSON output in dbt-run-and-watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ Or collapse both steps into one with the wrapper:
 - run: scherlok dbt-run-and-watch --project-dir . --target prod --fail-on critical
 ```
 
+For CI parsers, add `--output json` to the wrapper. It emits the same JSON
+payload as `scherlok dbt --output json`; live `dbt run` logs go to stderr while
+stdout remains parser-safe JSON:
+
+```yaml
+- run: scherlok dbt-run-and-watch --project-dir . --target prod --output json
+```
+
 **Supported adapters:** `postgres`, `bigquery`, `snowflake`, `mysql`, `duckdb`. For others, pass `--connection-string` explicitly.
 
 📖 Full docs: [dbt integration guide →](src/scherlok/dbt/README.md)

--- a/src/scherlok/cli.py
+++ b/src/scherlok/cli.py
@@ -3,6 +3,7 @@
 import json
 import shutil
 import subprocess
+import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -819,6 +820,10 @@ def dbt_run_and_watch(
         "critical", "--fail-on",
         help="Severity that triggers exit code 1: 'critical' (default) or 'warning'",
     ),
+    output: str = typer.Option(
+        "text", "--output",
+        help="Output format: 'text' (default) or 'json' for CI parsers",
+    ),
     show_lineage: bool = typer.Option(
         False, "--show-lineage",
         help="After each model's result, print an ASCII tree of its upstream "
@@ -838,53 +843,85 @@ def dbt_run_and_watch(
 
     Example:
         scherlok dbt-run-and-watch --project-dir . --target prod --fail-on critical
+        scherlok dbt-run-and-watch --project-dir . --target prod --output json
     """
-    dbt_bin = shutil.which("dbt")
-    if dbt_bin is None:
-        out_error(
-            "[red]`dbt` binary not found on PATH. Install dbt-core (or your adapter) "
-            "and re-run.[/red]"
+    output_lower = output.lower()
+    if output_lower not in ("text", "json"):
+        console.print(
+            f"[red]Invalid --output value '{output}'. Use 'text' or 'json'.[/red]"
         )
         raise typer.Exit(code=1)
+    json_mode = output_lower == "json"
 
-    cmd: list[str] = [dbt_bin, "run", "--project-dir", project_dir]
-    if profiles_dir:
-        cmd.extend(["--profiles-dir", profiles_dir])
-    if target:
-        cmd.extend(["--target", target])
-    for s in select or []:
-        cmd.extend(["--select", s])
+    from scherlok.output import is_quiet, is_verbose, set_stderr, set_verbosity
+    prev_quiet = is_quiet()
+    prev_verbose = is_verbose()
+    if json_mode:
+        # Keep stdout reserved for the JSON payload while preserving live logs.
+        set_stderr(True)
+        set_verbosity(quiet=True)
 
-    out_info(f"[bold]Running:[/bold] {' '.join(cmd)}")
-    # Stream stdout live so long dbt runs surface progress in CI logs.
-    # We don't capture output -- piping it through scherlok would buffer it.
-    completed = subprocess.run(cmd, check=False)
-    if completed.returncode != 0:
-        out_error(
-            f"[red]`dbt run` failed with exit code {completed.returncode}. "
-            f"Skipping scherlok watch (manifest may be stale).[/red]"
+    try:
+        dbt_bin = shutil.which("dbt")
+        if dbt_bin is None:
+            message = (
+                "`dbt` binary not found on PATH. Install dbt-core (or your adapter) "
+                "and re-run."
+            )
+            if json_mode:
+                print(json.dumps({"error": message, "exit_code": 1}))
+            else:
+                out_error(f"[red]{message}[/red]")
+            raise typer.Exit(code=1)
+
+        cmd: list[str] = [dbt_bin, "run", "--project-dir", project_dir]
+        if profiles_dir:
+            cmd.extend(["--profiles-dir", profiles_dir])
+        if target:
+            cmd.extend(["--target", target])
+        for s in select or []:
+            cmd.extend(["--select", s])
+
+        out_info(f"[bold]Running:[/bold] {' '.join(cmd)}")
+        # Stream dbt output live; JSON mode moves it to stderr so stdout stays parseable.
+        if json_mode:
+            completed = subprocess.run(cmd, check=False, stdout=sys.stderr)
+        else:
+            completed = subprocess.run(cmd, check=False)
+        if completed.returncode != 0:
+            message = (
+                f"`dbt run` failed with exit code {completed.returncode}. "
+                "Skipping scherlok watch (manifest may be stale)."
+            )
+            if json_mode:
+                print(json.dumps({"error": message, "exit_code": completed.returncode}))
+            else:
+                out_error(f"[red]{message}[/red]")
+            raise typer.Exit(code=completed.returncode)
+
+        out_info("[green]dbt run succeeded.[/green] Profiling materialized models...")
+        # Call the implementation function (not the Typer-decorated `dbt`) so the
+        # parameter defaults resolve to actual values instead of `OptionInfo`
+        # sentinels. Pass every kwarg explicitly; `_dbt_impl` is keyword-only.
+        _dbt_impl(
+            project_dir=project_dir,
+            profiles_dir=profiles_dir,
+            target=target,
+            connection_string=connection_string,
+            select=select,
+            include_sources=include_sources,
+            include_snapshots=include_snapshots,
+            webhook=webhook,
+            email=email or None,
+            fail_on=fail_on,
+            json_mode=json_mode,
+            show_lineage=show_lineage,
+            explain=explain,
         )
-        raise typer.Exit(code=completed.returncode)
-
-    out_info("[green]dbt run succeeded.[/green] Profiling materialized models...")
-    # Call the implementation function (not the Typer-decorated `dbt`) so the
-    # parameter defaults resolve to actual values instead of `OptionInfo`
-    # sentinels. Pass every kwarg explicitly; `_dbt_impl` is keyword-only.
-    _dbt_impl(
-        project_dir=project_dir,
-        profiles_dir=profiles_dir,
-        target=target,
-        connection_string=connection_string,
-        select=select,
-        include_sources=include_sources,
-        include_snapshots=include_snapshots,
-        webhook=webhook,
-        email=email or None,
-        fail_on=fail_on,
-        json_mode=False,
-        show_lineage=show_lineage,
-        explain=explain,
-    )
+    finally:
+        if json_mode:
+            set_stderr(False)
+            set_verbosity(verbose=prev_verbose, quiet=prev_quiet)
 
 
 def _resolve_physical_table(node: object, visible: set[str]) -> str | None:

--- a/src/scherlok/dbt/README.md
+++ b/src/scherlok/dbt/README.md
@@ -88,6 +88,15 @@ If your CI step is just `dbt run` then `scherlok dbt`, collapse them into one in
 
 The wrapper streams `dbt run` output live. If `dbt run` exits non-zero, the wrapper propagates the exit code and skips the watch (a stale or partial manifest would surface noise, not signal). `--project-dir`, `--target`, `--profiles-dir`, and `--select` are forwarded to `dbt run`; everything else stays scherlok-only.
 
+For parser-safe CI output, add `--output json`:
+
+```yaml
+- run: scherlok dbt-run-and-watch --project-dir . --target prod --output json
+```
+
+This emits the same JSON payload as `scherlok dbt --output json`. `dbt run`
+logs still stream live to stderr, while stdout contains only the JSON document.
+
 ## Lineage and downstream impact
 
 Scherlok reads `parent_map` from `manifest.json` to know each model's place in the DAG. Two features use it:

--- a/tests/test_dbt_run_and_watch.py
+++ b/tests/test_dbt_run_and_watch.py
@@ -1,7 +1,10 @@
 """Tests for `scherlok dbt-run-and-watch` CLI command."""
 
+import json
 import re
+import sys
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from typer.testing import CliRunner
@@ -132,6 +135,107 @@ def test_dbt_run_and_watch_calls_scherlok_dbt_on_success():
     assert kwargs["json_mode"] is False  # wrapper always runs the human-readable path
 
 
+def test_dbt_run_and_watch_json_passes_json_mode():
+    """`--output json` must pass JSON mode through to the dbt implementation."""
+    fake_run = MagicMock()
+    fake_run.return_value.returncode = 0
+
+    with patch("scherlok.cli.shutil.which", return_value="/usr/local/bin/dbt"), \
+         patch("scherlok.cli.subprocess.run", fake_run), \
+         patch("scherlok.cli._dbt_impl") as mock_impl:
+        result = runner.invoke(
+            app,
+            [
+                "dbt-run-and-watch",
+                "--project-dir", str(PG_PROJECT),
+                "--connection-string", "postgresql://u:p@h/d",
+                "--output", "json",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert mock_impl.call_args.kwargs["json_mode"] is True
+
+
+def test_dbt_run_and_watch_json_failure_is_parseable_and_skips_watch():
+    """A failed dbt run emits JSON and preserves its exit code without watching."""
+    fake_run = MagicMock()
+    fake_run.return_value.returncode = 2
+
+    with patch("scherlok.cli.shutil.which", return_value="/usr/local/bin/dbt"), \
+         patch("scherlok.cli.subprocess.run", fake_run), \
+         patch("scherlok.cli._dbt_impl") as mock_impl:
+        result = runner.invoke(
+            app,
+            [
+                "dbt-run-and-watch",
+                "--project-dir", str(PG_PROJECT),
+                "--output", "json",
+            ],
+        )
+
+    assert result.exit_code == 2
+    payload = json.loads(result.stdout)
+    assert payload["exit_code"] == 2
+    assert "dbt run" in payload["error"]
+    assert mock_impl.call_count == 0
+
+
+def test_dbt_run_and_watch_json_redirects_dbt_output_to_stderr(
+    tmp_path, monkeypatch
+):
+    """dbt output stays live but is sent to stderr in JSON mode."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    fake_conn = MagicMock()
+    fake_conn.connect.return_value = True
+    fake_conn.list_tables.return_value = [
+        "stg_customers", "stg_orders", "fct_orders", "dim_customers_inc",
+    ]
+
+    observed: dict[str, object] = {}
+
+    def fake_run(cmd, check, stdout):
+        observed["stdout"] = stdout
+        observed["stderr"] = sys.stderr
+        stdout.write("dbt log\n")
+        return SimpleNamespace(returncode=0)
+
+    with patch("scherlok.cli.get_connector", return_value=fake_conn), \
+         patch("scherlok.cli.shutil.which", return_value="/usr/local/bin/dbt"), \
+         patch("scherlok.cli.subprocess.run", side_effect=fake_run), \
+         patch("scherlok.cli._watch_table", return_value=([], {"row_count": 1})):
+        result = runner.invoke(
+            app,
+            [
+                "dbt-run-and-watch",
+                "--project-dir", str(PG_PROJECT),
+                "--connection-string", "postgresql://u:p@h/d",
+                "--output", "json",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert observed["stdout"] is observed["stderr"]
+    assert "dbt log" in result.stderr
+    assert "dbt log" not in result.stdout
+    json.loads(result.stdout)
+
+
+def test_dbt_run_and_watch_invalid_output_rejected():
+    """Unknown --output values use the same validation as `scherlok dbt`."""
+    result = runner.invoke(
+        app,
+        [
+            "dbt-run-and-watch",
+            "--project-dir", str(PG_PROJECT),
+            "--output", "yaml",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Invalid --output value 'yaml'. Use 'text' or 'json'." in result.output
+
+
 @patch("scherlok.cli.get_connector")
 def test_dbt_run_and_watch_real_dbt_impl_path(mock_get_connector, tmp_path, monkeypatch):
     """Run with `_dbt_impl` not mocked so OptionInfo-sentinel-class bugs surface.
@@ -175,3 +279,41 @@ def test_dbt_run_and_watch_real_dbt_impl_path(mock_get_connector, tmp_path, monk
     # keyword-only contract is intact end-to-end.
     assert result.exit_code == 0, result.output
     assert mock_watch.call_count == 4  # 4 materialized models in the fixture
+
+
+@patch("scherlok.cli.get_connector")
+def test_dbt_run_and_watch_json_real_dbt_impl_path(mock_get_connector, tmp_path, monkeypatch):
+    """JSON mode keeps the real `_dbt_impl` payload clean on stdout."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    fake_conn = MagicMock()
+    fake_conn.connect.return_value = True
+    fake_conn.list_tables.return_value = [
+        "stg_customers", "stg_orders", "fct_orders", "dim_customers_inc",
+    ]
+    mock_get_connector.return_value = fake_conn
+
+    fake_run = MagicMock()
+    fake_run.return_value.returncode = 0
+
+    with patch("scherlok.cli.shutil.which", return_value="/usr/local/bin/dbt"), \
+         patch("scherlok.cli.subprocess.run", fake_run), \
+         patch("scherlok.cli._watch_table", return_value=([], {"row_count": 1})):
+        result = runner.invoke(
+            app,
+            [
+                "dbt-run-and-watch",
+                "--project-dir", str(PG_PROJECT),
+                "--connection-string", "postgresql://u:p@h/d",
+                "--output", "json",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["project_dir"] == str(PG_PROJECT)
+    assert payload["summary"]["profiled"] == 4
+    assert "Running:" not in result.stdout
+    assert "dbt run succeeded." not in result.stdout
+    assert "Investigating" not in result.stdout
+    assert "Summary:" not in result.stdout


### PR DESCRIPTION
## Summary

Adds `--output json` support to `scherlok dbt-run-and-watch`, matching the existing JSON output behavior of `scherlok dbt`.

- adds `--output text|json` to `dbt-run-and-watch`
- keeps stdout parser-safe in JSON mode
- streams live `dbt run` output to stderr in JSON mode
- emits a JSON error document when `dbt run` fails while preserving its exit code
- passes JSON mode through to the existing `_dbt_impl` path
- adds focused success/failure/redirection/validation coverage
- updates the main and dbt integration docs

Closes #47

## Validation

- `tests/test_dbt_run_and_watch.py`: 11 passed
- `tests/test_dbt_cli.py`: 13 passed
- full suite: 348 passed, 1 pre-existing Windows DuckDB path failure
- `ruff check src/ tests/`: passed
- compile check: passed
- `git diff --check`: passed

The remaining full-suite failure is the existing Windows-specific DuckDB path issue in `test_connect_failure_sets_last_error` and is unrelated to this change.