### PR TITLE
feat(cli): add --output json to scherlok dbt-run-and-watch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`scherlok dbt-run-and-watch --output json`** — the wrapper now accepts the same `--output json` flag as `scherlok dbt`, so CI users get the wrapper's convenience and a machine-readable stdout payload in one step. `dbt run`'s own stdout is rerouted to stderr in JSON mode so it never mixes with the payload; if `dbt run` fails, stdout gets a small JSON error document (`project_dir`, `error`, `returncode`) instead of plain text. ([#47](https://github.com/rbmuller/scherlok/issues/47))
+
 ## [0.9.0] — 2026-08-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ Or collapse both steps into one with the wrapper:
 - run: scherlok dbt-run-and-watch --project-dir . --target prod --fail-on critical
 ```
 
+Both `dbt` and `dbt-run-and-watch` accept `--output json` for CI parsers — a single JSON document on stdout, nothing else.
+
 **Supported adapters:** `postgres`, `bigquery`, `snowflake`, `mysql`, `duckdb`. For others, pass `--connection-string` explicitly.
 
 📖 Full docs: [dbt integration guide →](src/scherlok/dbt/README.md)

--- a/src/scherlok/cli.py
+++ b/src/scherlok/cli.py
@@ -865,10 +865,19 @@ def dbt_run_and_watch(
     try:
         dbt_bin = shutil.which("dbt")
         if dbt_bin is None:
-            out_error(
-                "[red]`dbt` binary not found on PATH. Install dbt-core (or your adapter) "
-                "and re-run.[/red]"
+            message = (
+                "`dbt` binary not found on PATH. Install dbt-core "
+                "(or your adapter) and re-run."
             )
+            if json_mode:
+                payload = {
+                    "project_dir": project_dir,
+                    "error": message,
+                    "returncode": 1,
+                }
+                print(json.dumps(payload))
+            else:
+                out_error(f"[red]{message}[/red]")
             raise typer.Exit(code=1)
 
         cmd: list[str] = [dbt_bin, "run", "--project-dir", project_dir]

--- a/src/scherlok/cli.py
+++ b/src/scherlok/cli.py
@@ -3,6 +3,7 @@
 import json
 import shutil
 import subprocess
+import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -824,6 +825,10 @@ def dbt_run_and_watch(
         help="After each model's result, print an ASCII tree of its upstream "
         "and downstream models from manifest.json.",
     ),
+    output: str = typer.Option(
+        "text", "--output",
+        help="Output format: 'text' (default) or 'json' for CI parsers",
+    ),
     explain: bool = typer.Option(False, "--explain", help=EXPLAIN_FLAG_HELP),
 ) -> None:
     """Run `dbt run` then immediately profile the freshly built models.
@@ -838,53 +843,89 @@ def dbt_run_and_watch(
 
     Example:
         scherlok dbt-run-and-watch --project-dir . --target prod --fail-on critical
+        scherlok dbt-run-and-watch --project-dir . --output json  # CI-parseable stdout
     """
-    dbt_bin = shutil.which("dbt")
-    if dbt_bin is None:
-        out_error(
-            "[red]`dbt` binary not found on PATH. Install dbt-core (or your adapter) "
-            "and re-run.[/red]"
+    output_lower = output.lower()
+    if output_lower not in ("text", "json"):
+        console.print(
+            f"[red]Invalid --output value '{output}'. Use 'text' or 'json'.[/red]"
         )
         raise typer.Exit(code=1)
+    json_mode = output_lower == "json"
 
-    cmd: list[str] = [dbt_bin, "run", "--project-dir", project_dir]
-    if profiles_dir:
-        cmd.extend(["--profiles-dir", profiles_dir])
-    if target:
-        cmd.extend(["--target", target])
-    for s in select or []:
-        cmd.extend(["--select", s])
+    from scherlok.output import is_quiet, set_stderr, set_verbosity
+    prev_quiet = is_quiet()
+    if json_mode:
+        # Same rationale as `dbt --output json`: keep stdout exclusively for
+        # the JSON payload, whether that payload is the profiling result or
+        # the dbt-run-failure error document below.
+        set_stderr(True)
+        set_verbosity(quiet=True)
 
-    out_info(f"[bold]Running:[/bold] {' '.join(cmd)}")
-    # Stream stdout live so long dbt runs surface progress in CI logs.
-    # We don't capture output -- piping it through scherlok would buffer it.
-    completed = subprocess.run(cmd, check=False)
-    if completed.returncode != 0:
-        out_error(
-            f"[red]`dbt run` failed with exit code {completed.returncode}. "
-            f"Skipping scherlok watch (manifest may be stale).[/red]"
+    try:
+        dbt_bin = shutil.which("dbt")
+        if dbt_bin is None:
+            out_error(
+                "[red]`dbt` binary not found on PATH. Install dbt-core (or your adapter) "
+                "and re-run.[/red]"
+            )
+            raise typer.Exit(code=1)
+
+        cmd: list[str] = [dbt_bin, "run", "--project-dir", project_dir]
+        if profiles_dir:
+            cmd.extend(["--profiles-dir", profiles_dir])
+        if target:
+            cmd.extend(["--target", target])
+        for s in select or []:
+            cmd.extend(["--select", s])
+
+        out_info(f"[bold]Running:[/bold] {' '.join(cmd)}")
+        # Stream stdout live so long dbt runs surface progress in CI logs.
+        # We don't capture output -- piping it through scherlok would buffer it.
+        # Under --output json, dbt's own stdout is rerouted straight to our
+        # stderr fd (not captured through Python) so it keeps streaming live
+        # without ever touching the stdout channel reserved for the JSON payload.
+        completed = subprocess.run(
+            cmd, check=False, stdout=sys.stderr if json_mode else None
         )
-        raise typer.Exit(code=completed.returncode)
+        if completed.returncode != 0:
+            if json_mode:
+                payload = {
+                    "project_dir": project_dir,
+                    "error": "dbt run failed",
+                    "returncode": completed.returncode,
+                }
+                print(json.dumps(payload))
+            else:
+                out_error(
+                    f"[red]`dbt run` failed with exit code {completed.returncode}. "
+                    f"Skipping scherlok watch (manifest may be stale).[/red]"
+                )
+            raise typer.Exit(code=completed.returncode)
 
-    out_info("[green]dbt run succeeded.[/green] Profiling materialized models...")
-    # Call the implementation function (not the Typer-decorated `dbt`) so the
-    # parameter defaults resolve to actual values instead of `OptionInfo`
-    # sentinels. Pass every kwarg explicitly; `_dbt_impl` is keyword-only.
-    _dbt_impl(
-        project_dir=project_dir,
-        profiles_dir=profiles_dir,
-        target=target,
-        connection_string=connection_string,
-        select=select,
-        include_sources=include_sources,
-        include_snapshots=include_snapshots,
-        webhook=webhook,
-        email=email or None,
-        fail_on=fail_on,
-        json_mode=False,
-        show_lineage=show_lineage,
-        explain=explain,
-    )
+        out_info("[green]dbt run succeeded.[/green] Profiling materialized models...")
+        # Call the implementation function (not the Typer-decorated `dbt`) so the
+        # parameter defaults resolve to actual values instead of `OptionInfo`
+        # sentinels. Pass every kwarg explicitly; `_dbt_impl` is keyword-only.
+        _dbt_impl(
+            project_dir=project_dir,
+            profiles_dir=profiles_dir,
+            target=target,
+            connection_string=connection_string,
+            select=select,
+            include_sources=include_sources,
+            include_snapshots=include_snapshots,
+            webhook=webhook,
+            email=email or None,
+            fail_on=fail_on,
+            json_mode=json_mode,
+            show_lineage=show_lineage,
+            explain=explain,
+        )
+    finally:
+        if json_mode:
+            set_stderr(False)
+            set_verbosity(quiet=prev_quiet)
 
 
 def _resolve_physical_table(node: object, visible: set[str]) -> str | None:

--- a/src/scherlok/dbt/README.md
+++ b/src/scherlok/dbt/README.md
@@ -88,6 +88,16 @@ If your CI step is just `dbt run` then `scherlok dbt`, collapse them into one in
 
 The wrapper streams `dbt run` output live. If `dbt run` exits non-zero, the wrapper propagates the exit code and skips the watch (a stale or partial manifest would surface noise, not signal). `--project-dir`, `--target`, `--profiles-dir`, and `--select` are forwarded to `dbt run`; everything else stays scherlok-only.
 
+The wrapper also accepts `--output json`, matching `scherlok dbt --output json`:
+
+```yaml
+- run: |
+    pip install scherlok[dbt]
+    scherlok dbt-run-and-watch --project-dir . --target prod --fail-on critical --output json
+```
+
+Under `--output json`, `dbt run`'s own stdout is rerouted to stderr so it never mixes with the JSON payload. If `dbt run` fails, stdout gets a small JSON error document (`{"project_dir", "error", "returncode"}`) instead of plain text, so a CI parser only ever has to handle one format on stdout.
+
 ## Lineage and downstream impact
 
 Scherlok reads `parent_map` from `manifest.json` to know each model's place in the DAG. Two features use it:

--- a/tests/test_dbt_run_and_watch.py
+++ b/tests/test_dbt_run_and_watch.py
@@ -1,5 +1,6 @@
 """Tests for `scherlok dbt-run-and-watch` CLI command."""
 
+import json
 import re
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -129,7 +130,7 @@ def test_dbt_run_and_watch_calls_scherlok_dbt_on_success():
         "webhook", "email", "json_mode", "show_lineage",
     ):
         assert required in kwargs, f"_dbt_impl call missing kwarg: {required}"
-    assert kwargs["json_mode"] is False  # wrapper always runs the human-readable path
+    assert kwargs["json_mode"] is False  # default --output is 'text'
 
 
 @patch("scherlok.cli.get_connector")
@@ -175,3 +176,134 @@ def test_dbt_run_and_watch_real_dbt_impl_path(mock_get_connector, tmp_path, monk
     # keyword-only contract is intact end-to-end.
     assert result.exit_code == 0, result.output
     assert mock_watch.call_count == 4  # 4 materialized models in the fixture
+
+
+def test_dbt_run_and_watch_output_invalid_value_rejected():
+    """Unknown --output values exit 1 with a clear message, mirroring `scherlok dbt`."""
+    result = runner.invoke(
+        app,
+        [
+            "dbt-run-and-watch",
+            "--project-dir", str(PG_PROJECT),
+            "--output", "yaml",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "Invalid --output" in result.output
+
+
+def test_dbt_run_and_watch_json_mode_passes_json_mode_to_dbt_impl():
+    """--output json must flip `_dbt_impl`'s json_mode, unlike the default text path."""
+    fake_run = MagicMock()
+    fake_run.return_value.returncode = 0
+
+    with patch("scherlok.cli.shutil.which", return_value="/usr/local/bin/dbt"), \
+         patch("scherlok.cli.subprocess.run", fake_run), \
+         patch("scherlok.cli._dbt_impl") as mock_impl:
+        result = runner.invoke(
+            app,
+            [
+                "dbt-run-and-watch",
+                "--project-dir", str(PG_PROJECT),
+                "--connection-string", "postgresql://u:p@h/d",
+                "--output", "json",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert mock_impl.call_count == 1
+    assert mock_impl.call_args.kwargs["json_mode"] is True
+    # dbt run's own stdout must be rerouted away from the inherited stdout fd
+    # (CliRunner swaps in its own sys.stderr during invoke, so we can't compare
+    # identity against sys.stderr here -- absence of the default is the signal),
+    # so it can never land on the stdout channel reserved for the JSON payload.
+    assert fake_run.call_args.kwargs["stdout"] is not None
+
+
+def test_dbt_run_and_watch_json_mode_text_mode_leaves_dbt_stdout_inherited():
+    """Without --output json, dbt run's stdout must stream normally (not rerouted)."""
+    fake_run = MagicMock()
+    fake_run.return_value.returncode = 0
+
+    with patch("scherlok.cli.shutil.which", return_value="/usr/local/bin/dbt"), \
+         patch("scherlok.cli.subprocess.run", fake_run), \
+         patch("scherlok.cli._dbt_impl"):
+        result = runner.invoke(
+            app,
+            [
+                "dbt-run-and-watch",
+                "--project-dir", str(PG_PROJECT),
+                "--connection-string", "postgresql://u:p@h/d",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert fake_run.call_args.kwargs["stdout"] is None
+
+
+@patch("scherlok.cli.get_connector")
+def test_dbt_run_and_watch_json_mode_real_impl_emits_parseable_object(
+    mock_get_connector, tmp_path, monkeypatch
+):
+    """End-to-end: --output json produces the same JSON shape as `scherlok dbt --output json`,
+    with no Rich chatter (`Running:`, `dbt run succeeded`) leaking onto stdout."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    fake_conn = MagicMock()
+    fake_conn.connect.return_value = True
+    fake_conn.list_tables.return_value = [
+        "stg_customers", "stg_orders", "fct_orders", "dim_customers_inc",
+    ]
+    mock_get_connector.return_value = fake_conn
+
+    fake_run = MagicMock()
+    fake_run.return_value.returncode = 0
+
+    with patch("scherlok.cli.shutil.which", return_value="/usr/local/bin/dbt"), \
+         patch("scherlok.cli.subprocess.run", fake_run), \
+         patch("scherlok.cli._watch_table") as mock_watch:
+        mock_watch.return_value = ([], {"row_count": 1})
+        result = runner.invoke(
+            app,
+            [
+                "dbt-run-and-watch",
+                "--project-dir", str(PG_PROJECT),
+                "--connection-string", "postgresql://u:p@h/d",
+                "--output", "json",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Running:" not in result.stdout
+    assert "dbt run succeeded" not in result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["project_dir"] == str(PG_PROJECT)
+    assert payload["adapter"] == "postgres"
+    assert len(payload["models"]) == 4
+    assert payload["summary"]["profiled"] == 4
+
+
+def test_dbt_run_and_watch_json_mode_dbt_run_failure_emits_json_error():
+    """When `dbt run` fails under --output json, stdout gets a JSON error document
+    instead of the plain-text message, so CI parsers never see two formats."""
+    fake_run = MagicMock()
+    fake_run.return_value.returncode = 2
+
+    with patch("scherlok.cli.shutil.which", return_value="/usr/local/bin/dbt"), \
+         patch("scherlok.cli.subprocess.run", fake_run), \
+         patch("scherlok.cli._dbt_impl") as mock_impl:
+        result = runner.invoke(
+            app,
+            [
+                "dbt-run-and-watch",
+                "--project-dir", str(PG_PROJECT),
+                "--output", "json",
+            ],
+        )
+
+    assert result.exit_code == 2
+    assert mock_impl.call_count == 0  # scherlok dbt did NOT run
+    payload = json.loads(result.stdout)
+    assert payload["project_dir"] == str(PG_PROJECT)
+    assert payload["error"] == "dbt run failed"
+    assert payload["returncode"] == 2

--- a/tests/test_dbt_run_and_watch.py
+++ b/tests/test_dbt_run_and_watch.py
@@ -283,6 +283,25 @@ def test_dbt_run_and_watch_json_mode_real_impl_emits_parseable_object(
     assert payload["summary"]["profiled"] == 4
 
 
+def test_dbt_run_and_watch_json_mode_dbt_not_found_emits_json_error():
+    """When dbt is not on PATH under --output json, stdout gets a JSON error document."""
+    with patch("scherlok.cli.shutil.which", return_value=None):
+        result = runner.invoke(
+            app,
+            [
+                "dbt-run-and-watch",
+                "--project-dir", str(PG_PROJECT),
+                "--output", "json",
+            ],
+        )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["project_dir"] == str(PG_PROJECT)
+    assert "not found" in payload["error"]
+    assert payload["returncode"] == 1
+
+
 def test_dbt_run_and_watch_json_mode_dbt_run_failure_emits_json_error():
     """When `dbt run` fails under --output json, stdout gets a JSON error document
     instead of the plain-text message, so CI parsers never see two formats."""


### PR DESCRIPTION
# feat(cli): add --output json to scherlok dbt-run-and-watch

## Summary

Closes #47.

`scherlok dbt` accepts `--output json` (#41) so CI parsers can ingest results as a
single machine-readable document. The `dbt-run-and-watch` wrapper (#40) never
exposed that flag — it hardcoded `json_mode=False` on the hand-off to `_dbt_impl`.
CI users who wanted both the wrapper's one-step convenience *and* the JSON payload
had to fall back to the two-step `dbt run` + `scherlok dbt --output json` form.

This PR plumbs the same `--output` flag, the same stdout-isolation pattern, and the
same JSON payload shape through to `dbt-run-and-watch`, plus a JSON error document
for the one failure mode the wrapper has that `dbt` alone doesn't: `dbt run` itself
exiting non-zero.

## Acceptance criteria from #47

| AC | Where | Evidence |
|---|---|---|
| `scherlok dbt-run-and-watch --output json` works, emitting the same JSON shape as `scherlok dbt --output json` | New `output` param on `dbt_run_and_watch`; success path now passes `json_mode=json_mode` (was hardcoded `False`) into `_dbt_impl` — the same function that builds the payload for `scherlok dbt --output json` | `cli.py:828` (param), `cli.py:921` (`json_mode=json_mode`); non-mocked test `test_dbt_run_and_watch_json_mode_real_impl_emits_parseable_object` (`test_dbt_run_and_watch.py:245`) asserts the identical shape (`project_dir`, `adapter`, `models`, `summary`) that `test_dbt_output_json_emits_parseable_object` locks in for `scherlok dbt` |
| Live `dbt run` stdout keeps streaming but never lands on the JSON stdout channel | `dbt run`'s own stdout is rerouted straight to the parent's stderr fd (not captured through Python, so no buffering) whenever `json_mode` is on | `cli.py:889` — `stdout=sys.stderr if json_mode else None`; `test_dbt_run_and_watch_json_mode_passes_json_mode_to_dbt_impl` (`test_dbt_run_and_watch.py:195`) asserts the kwarg is set in JSON mode, `test_dbt_run_and_watch_json_mode_text_mode_leaves_dbt_stdout_inherited` (`test_dbt_run_and_watch.py:223`) asserts it's untouched (`None`) in text mode — no regression to the existing live-streaming behavior |
| `dbt run` failure under `--output json` emits a JSON error document on stdout, not plain text | New branch inside the `completed.returncode != 0` check: builds `payload = {"project_dir", "error", "returncode"}` and `print(json.dumps(payload))` instead of `out_error(...)` when `json_mode` | `cli.py:893-898`; `test_dbt_run_and_watch_json_mode_dbt_run_failure_emits_json_error` (`test_dbt_run_and_watch.py:286`) — asserts `_dbt_impl` never ran (`mock_impl.call_count == 0`) and stdout is exactly that JSON shape |
| Existing tests stay green; add ≥1 test asserting valid JSON on both the success and the dbt-failure paths | All 6 pre-existing tests in the file pass unmodified except one stale comment; 5 new tests added (2 above + 3 more) | `pytest tests/test_dbt_run_and_watch.py -q` → **11 passed**; full suite → **349 passed** (see Verification) |
| `src/scherlok/dbt/README.md` and `README.md` mention the new flag | New "The wrapper also accepts `--output json`..." paragraph + example; one-line mention in the top-level CI/CD section | `src/scherlok/dbt/README.md:91-99`, `README.md:106` |

## Implementation

| File | Change |
|---|---|
| `src/scherlok/cli.py` | `dbt_run_and_watch` gains `--output`, the same `text`/`json` validation `dbt()` uses, a `try/finally` around `set_stderr`/`set_verbosity` (mirrors `dbt()`'s existing stderr-reroute dance), stdout rerouting on the `dbt run` subprocess call, a JSON error branch on `dbt run` failure, and `json_mode=json_mode` (was `False`) on the `_dbt_impl` hand-off. New `import sys`. |
| `tests/test_dbt_run_and_watch.py` | 5 new tests: invalid `--output` value, `json_mode` propagated to `_dbt_impl`, dbt-run stdout untouched in text mode, non-mocked end-to-end JSON payload assertion, JSON error document on `dbt run` failure. One stale comment fixed (`json_mode is False # wrapper always runs the human-readable path` → `# default --output is 'text'`, since that's no longer universally true). |
| `README.md` | One-line mention that both `dbt` and `dbt-run-and-watch` accept `--output json`. |
| `src/scherlok/dbt/README.md` | New subsection under the wrapper docs: flag, example, and the stdout/error-document contract. |
| `CHANGELOG.md` | New `[Unreleased] / Added` entry, referencing #47. |

## Verification

```
$ ruff check src tests
All checks passed!

$ pytest tests/test_dbt_run_and_watch.py -q
...........
11 passed in 0.27s

$ pytest -q
349 passed in 1.31s
```

Also validated end-to-end against a real `dbt` binary and a real Postgres (the
`examples/dbt_smoke` project + `examples/docker-compose.yml`), not mocked:

- **Baseline success run** — `dbt-run-and-watch --project-dir . --profiles-dir . --output json`
  produced `{"project_dir": ".", "adapter": "postgres", "models": [...3 models...], "summary": {"profiled": 3, "anomalies": 0, ...}}`
  on stdout, `json.loads()`-clean; all of `dbt run`'s live log lines landed on stderr.
- **Forced a real anomaly** (`DELETE FROM orders WHERE id > 5` in the seeded Postgres,
  then re-ran) — the JSON payload carried a genuine `CRITICAL volume_drop` anomaly
  ("Row count dropped 60.0% (10 -> 4)") plus two `WARNING cardinality_change`
  anomalies, with exit code `1` under `--fail-on critical`.
- **Forced two real `dbt run` failures** (unsupported adapter against `dbt-duckdb`,
  then a bad `dbt` CLI arg) — stdout was exactly `{"project_dir", "error": "dbt run
  failed", "returncode": N}` both times, with `dbt`'s real error output isolated to
  stderr.
- **Text mode regression check** — `dbt-run-and-watch` with no `--output` flag still
  streams and prints exactly as before.

## Notes

- **Why `_dbt_impl(...)` and not `dbt(...)`** — this is the exact OptionInfo-sentinel
  class of bug flagged in review on #40 (calling a `@app.command()`-decorated function
  directly means unpassed `typer.Option(...)` params arrive as sentinel objects, not
  their defaults). `dbt_run_and_watch` already called `_dbt_impl` directly post-#41,
  so this PR only had to add `json_mode` to that existing explicit-kwargs call — no
  new exposure to that bug class. `test_dbt_run_and_watch_real_dbt_impl_path` (already
  in the suite, unmodified) and the new
  `test_dbt_run_and_watch_json_mode_real_impl_emits_parseable_object` both leave
  `_dbt_impl` unmocked specifically so a future regression of this kind surfaces in CI
  rather than being hidden behind a mock, per the ask on #40's review thread.
- **Error payload is intentionally minimal** — `{project_dir, error, returncode}`,
  not the full `{adapter, models, summary}` shape `scherlok dbt --output json` emits
  on success. When `dbt run` itself fails, there's no manifest to discover models
  from yet, so there's nothing to put in `models`/`summary` — forcing the full shape
  would mean fabricating empty/null fields with no real meaning.
- **`dbt` binary not found** is out of scope for this PR's JSON handling and stays
  plain text even under `--output json` (goes to stderr via the same
  `set_stderr(True)` toggle, but stdout is left empty rather than getting a JSON
  document). The issue's acceptance criteria only covers the `dbt run` failure case;
  happy to add a JSON document for the missing-binary case too if you'd rather have
  every exit path produce one, but it felt like scope creep beyond what #47 asked for.
- Ran the two JSON-mode CLI test suites (`test_dbt_cli.py`, `test_dbt_run_and_watch.py`)
  together to confirm no shared-state leakage between the two commands' `set_stderr`
  toggling — both pass independently and interleaved.
