### PR TITLE
feat(dbt): target profiling from run_results.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **`scherlok dbt-run-and-watch --output json`** — the wrapper now accepts the same `--output json` flag as `scherlok dbt`, so CI users get the wrapper's convenience and a machine-readable stdout payload in one step. `dbt run`'s own stdout is rerouted to stderr in JSON mode so it never mixes with the payload; if `dbt run` fails, stdout gets a small JSON error document (`project_dir`, `error`, `returncode`) instead of plain text. ([#47](https://github.com/rbmuller/scherlok/issues/47))
+- **Targeted `dbt-run-and-watch` profiling** — after a successful `dbt run`, the wrapper reads `target/run_results.json` and profiles only successful model nodes from that invocation. Missing or malformed artifacts fail clearly rather than falling back to the full manifest. ([#69](https://github.com/rbmuller/scherlok/issues/69))
 
 ## [0.9.0] — 2026-08-10
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ Or collapse both steps into one with the wrapper:
 - run: scherlok dbt-run-and-watch --project-dir . --target prod --fail-on critical
 ```
 
+The wrapper uses the successful model nodes recorded in `target/run_results.json` after `dbt run`, so partial runs profile only what dbt actually built.
+
 Both `dbt` and `dbt-run-and-watch` accept `--output json` for CI parsers — a single JSON document on stdout, nothing else.
 
 **Supported adapters:** `postgres`, `bigquery`, `snowflake`, `mysql`, `duckdb`. For others, pass `--connection-string` explicitly.

--- a/src/scherlok/cli.py
+++ b/src/scherlok/cli.py
@@ -617,6 +617,7 @@ def _dbt_impl(
     json_mode: bool,
     show_lineage: bool = False,
     explain: bool = False,
+    executed_model_ids: set[str] | None = None,
 ) -> None:
     """The actual dbt-command body. Extracted so the `dbt()` entry point can
     wrap it in a try/finally that restores the shared output console after
@@ -642,18 +643,55 @@ def _dbt_impl(
 
     adapter = manifest.get("metadata", {}).get("adapter_type", "?")
     nodes: list[DbtNode] = discover_models(manifest, include_snapshots=include_snapshots)
+    if executed_model_ids is not None:
+        nodes = [
+            node
+            for node in nodes
+            if node.resource_type != "model" or node.unique_id in executed_model_ids
+        ]
     if include_sources:
         nodes.extend(discover_sources(manifest))
 
     if select:
         wanted = set(select)
-        nodes = [n for n in nodes if n.name in wanted or n.identifier in wanted]
-        if not nodes:
+        if executed_model_ids is None:
+            nodes = [n for n in nodes if n.name in wanted or n.identifier in wanted]
+        else:
+            # dbt already expanded the selector. Keep model nodes from the
+            # artifact and retain literal matching for explicitly included
+            # sources/snapshots.
+            nodes = [
+                n
+                for n in nodes
+                if n.resource_type == "model" or n.name in wanted or n.identifier in wanted
+            ]
+        if not nodes and executed_model_ids is None:
             console.print(f"[red]No models matched --select {list(wanted)}.[/red]")
             raise typer.Exit(code=1)
 
     if not nodes:
-        console.print("[yellow]No materialized models found in manifest.[/yellow]")
+        if executed_model_ids is not None:
+            message = "No successfully executed dbt models found in run_results.json."
+            if json_mode:
+                print(
+                    json.dumps(
+                        {
+                            "project_dir": project_dir,
+                            "adapter": adapter,
+                            "models": [],
+                            "summary": {
+                                "profiled": 0,
+                                "anomalies": 0,
+                                "critical": 0,
+                                "warning": 0,
+                            },
+                        }
+                    )
+                )
+            else:
+                out_info(f"[yellow]{message}[/yellow]")
+        else:
+            console.print("[yellow]No materialized models found in manifest.[/yellow]")
         raise typer.Exit(code=0)
 
     # 2. Resolve connection string
@@ -912,7 +950,27 @@ def dbt_run_and_watch(
                 )
             raise typer.Exit(code=completed.returncode)
 
-        out_info("[green]dbt run succeeded.[/green] Profiling materialized models...")
+        out_info("[green]dbt run succeeded.[/green] Reading execution results...")
+        from scherlok.dbt import load_run_results, successful_model_unique_ids
+
+        try:
+            run_results = load_run_results(project_dir)
+            executed_model_ids = successful_model_unique_ids(run_results)
+        except (FileNotFoundError, OSError, ValueError) as exc:
+            message = (
+                "`dbt run` succeeded, but its run_results.json artifact could not be "
+                f"used: {exc}"
+            )
+            if json_mode:
+                print(
+                    json.dumps(
+                        {"project_dir": project_dir, "error": message, "returncode": 1}
+                    )
+                )
+            else:
+                out_error(f"[red]{message}[/red]")
+            raise typer.Exit(code=1) from exc
+
         # Call the implementation function (not the Typer-decorated `dbt`) so the
         # parameter defaults resolve to actual values instead of `OptionInfo`
         # sentinels. Pass every kwarg explicitly; `_dbt_impl` is keyword-only.
@@ -930,6 +988,7 @@ def dbt_run_and_watch(
             json_mode=json_mode,
             show_lineage=show_lineage,
             explain=explain,
+            executed_model_ids=executed_model_ids,
         )
     finally:
         if json_mode:

--- a/src/scherlok/cli.py
+++ b/src/scherlok/cli.py
@@ -951,11 +951,14 @@ def dbt_run_and_watch(
             raise typer.Exit(code=completed.returncode)
 
         out_info("[green]dbt run succeeded.[/green] Reading execution results...")
-        from scherlok.dbt import load_run_results, successful_model_unique_ids
+        from scherlok.dbt import load_run_results
+        from scherlok.dbt.run_results import _successful_model_unique_ids_from_validated
 
         try:
             run_results = load_run_results(project_dir)
-            executed_model_ids = successful_model_unique_ids(run_results)
+            executed_model_ids = _successful_model_unique_ids_from_validated(
+                run_results["results"]
+            )
         except (FileNotFoundError, OSError, ValueError) as exc:
             message = (
                 "`dbt run` succeeded, but its run_results.json artifact could not be "

--- a/src/scherlok/dbt/README.md
+++ b/src/scherlok/dbt/README.md
@@ -86,7 +86,9 @@ If your CI step is just `dbt run` then `scherlok dbt`, collapse them into one in
     scherlok dbt-run-and-watch --project-dir . --target prod --fail-on critical
 ```
 
-The wrapper streams `dbt run` output live. If `dbt run` exits non-zero, the wrapper propagates the exit code and skips the watch (a stale or partial manifest would surface noise, not signal). `--project-dir`, `--target`, `--profiles-dir`, and `--select` are forwarded to `dbt run`; everything else stays scherlok-only.
+The wrapper streams `dbt run` output live. If `dbt run` exits non-zero, the wrapper propagates the exit code and skips the watch (a stale or partial manifest would surface noise, not signal). After a successful run, it reads that invocation's `target/run_results.json` and profiles only successfully built model nodes. `--project-dir`, `--target`, `--profiles-dir`, and `--select` are forwarded to `dbt run`; everything else stays scherlok-only.
+
+If `run_results.json` is missing or malformed after a successful `dbt run`, the wrapper fails clearly instead of falling back to every model in the manifest. `--include-sources` and `--include-snapshots` remain explicit opt-ins and are not inferred from model execution results.
 
 The wrapper also accepts `--output json`, matching `scherlok dbt --output json`:
 

--- a/src/scherlok/dbt/__init__.py
+++ b/src/scherlok/dbt/__init__.py
@@ -14,6 +14,7 @@ from scherlok.dbt.lineage import (
 )
 from scherlok.dbt.manifest import DbtNode, discover_models, discover_sources, load_manifest
 from scherlok.dbt.profiles import ProfileResolutionError, resolve_connection_string
+from scherlok.dbt.run_results import load_run_results, successful_model_unique_ids
 
 __all__ = [
     "DbtNode",
@@ -25,7 +26,9 @@ __all__ = [
     "downstream_of",
     "invert_graph",
     "load_manifest",
+    "load_run_results",
     "render_lineage_tree",
     "resolve_connection_string",
+    "successful_model_unique_ids",
     "upstream_of",
 ]

--- a/src/scherlok/dbt/run_results.py
+++ b/src/scherlok/dbt/run_results.py
@@ -30,7 +30,13 @@ def load_run_results(project_dir: str | Path) -> dict[str, Any]:
 
 def successful_model_unique_ids(run_results: object) -> set[str]:
     """Return unique IDs for successfully executed dbt model nodes."""
-    results = _validated_results(run_results)
+    return _successful_model_unique_ids_from_validated(_validated_results(run_results))
+
+
+def _successful_model_unique_ids_from_validated(
+    results: list[dict[str, Any]],
+) -> set[str]:
+    """Return successful model IDs from rows already validated by the loader."""
     return {
         result["unique_id"]
         for result in results

--- a/src/scherlok/dbt/run_results.py
+++ b/src/scherlok/dbt/run_results.py
@@ -1,0 +1,69 @@
+"""Read dbt's target/run_results.json execution artifact."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_run_results(project_dir: str | Path) -> dict[str, Any]:
+    """Load and validate target/run_results.json from a dbt project."""
+    run_results_path = Path(project_dir) / "target" / "run_results.json"
+    if not run_results_path.is_file():
+        raise FileNotFoundError(
+            f"run_results.json not found at {run_results_path}. "
+            f"Run `dbt run` again."
+        )
+
+    try:
+        with run_results_path.open("r", encoding="utf-8") as f:
+            run_results = json.load(f)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise ValueError(
+            f"Malformed run_results.json at {run_results_path}: {exc}."
+        ) from exc
+
+    _validated_results(run_results)
+    return run_results
+
+
+def successful_model_unique_ids(run_results: object) -> set[str]:
+    """Return unique IDs for successfully executed dbt model nodes."""
+    results = _validated_results(run_results)
+    return {
+        result["unique_id"]
+        for result in results
+        if result["status"] == "success"
+        and result["unique_id"].startswith("model.")
+    }
+
+
+def _validated_results(run_results: object) -> list[dict[str, Any]]:
+    """Validate the artifact shape needed for execution filtering."""
+    if not isinstance(run_results, dict):
+        raise ValueError("Invalid run_results.json: top-level value must be an object.")
+
+    results = run_results.get("results")
+    if not isinstance(results, list):
+        raise ValueError("Invalid run_results.json: top-level `results` must be a list.")
+
+    validated: list[dict[str, Any]] = []
+    for index, result in enumerate(results):
+        if not isinstance(result, dict):
+            raise ValueError(
+                f"Invalid run_results.json: `results[{index}]` must be an object."
+            )
+        unique_id = result.get("unique_id")
+        status = result.get("status")
+        if not isinstance(unique_id, str) or not unique_id:
+            raise ValueError(
+                f"Invalid run_results.json: `results[{index}].unique_id` must be a string."
+            )
+        if not isinstance(status, str) or not status:
+            raise ValueError(
+                f"Invalid run_results.json: `results[{index}].status` must be a string."
+            )
+        validated.append(result)
+
+    return validated

--- a/tests/fixtures/dbt/jaffle_shop_postgres/target/run_results.json
+++ b/tests/fixtures/dbt/jaffle_shop_postgres/target/run_results.json
@@ -1,0 +1,24 @@
+{
+  "metadata": {
+    "dbt_schema_version": "https://schemas.getdbt.com/dbt/run-results/v5.json",
+    "dbt_version": "1.8.0"
+  },
+  "results": [
+    {
+      "unique_id": "model.jaffle_shop.stg_customers",
+      "status": "success"
+    },
+    {
+      "unique_id": "model.jaffle_shop.stg_orders",
+      "status": "success"
+    },
+    {
+      "unique_id": "model.jaffle_shop.fct_orders",
+      "status": "success"
+    },
+    {
+      "unique_id": "model.jaffle_shop.dim_customers_inc",
+      "status": "success"
+    }
+  ]
+}

--- a/tests/test_dbt_run_and_watch.py
+++ b/tests/test_dbt_run_and_watch.py
@@ -5,6 +5,7 @@ import re
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
 from typer.testing import CliRunner
 
 from scherlok.cli import app
@@ -16,6 +17,35 @@ PG_PROJECT = FIXTURES / "jaffle_shop_postgres"
 # CI terminals emit ANSI styling (bold/dim) even when colors are disabled;
 # strip them before substring assertions on Rich-rendered help text.
 ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _copy_project_with_run_results(
+    tmp_path: Path, results: list[dict[str, str]], *, include_snapshot: bool = False
+) -> Path:
+    """Copy the manifest fixture and replace its execution artifact."""
+    project_dir = tmp_path / "dbt_project"
+    target_dir = project_dir / "target"
+    target_dir.mkdir(parents=True)
+    manifest = json.loads((PG_PROJECT / "target" / "manifest.json").read_text())
+    if include_snapshot:
+        manifest["nodes"]["snapshot.jaffle_shop.orders_snapshot"] = {
+            "resource_type": "snapshot",
+            "name": "orders_snapshot",
+            "alias": "orders_snapshot",
+            "database": "jaffle_db",
+            "schema": "snapshots",
+            "relation_name": '"jaffle_db"."snapshots"."orders_snapshot"',
+            "config": {"materialized": "snapshot"},
+        }
+    (target_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    (target_dir / "run_results.json").write_text(
+        json.dumps({"results": results}), encoding="utf-8"
+    )
+    return project_dir
+
+
+def _successful_result(unique_id: str, status: str = "success") -> dict[str, str]:
+    return {"unique_id": unique_id, "status": status}
 
 
 def test_dbt_run_and_watch_help():
@@ -96,6 +126,227 @@ def test_dbt_run_and_watch_passes_select_through_to_dbt():
     assert mock_impl.call_args.kwargs["select"] == ["stg_orders", "fct_orders"]
 
 
+@patch("scherlok.cli.get_connector")
+def test_dbt_run_and_watch_profiles_only_successful_models(
+    mock_get_connector, tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    project_dir = _copy_project_with_run_results(
+        tmp_path,
+        [
+            _successful_result("model.jaffle_shop.stg_customers"),
+            _successful_result("model.jaffle_shop.stg_orders", "error"),
+            _successful_result("model.jaffle_shop.fct_orders", "skipped"),
+        ],
+    )
+    fake_conn = MagicMock()
+    fake_conn.connect.return_value = True
+    fake_conn.list_tables.return_value = ["stg_customers", "stg_orders", "fct_orders"]
+    mock_get_connector.return_value = fake_conn
+    fake_run = MagicMock()
+    fake_run.return_value.returncode = 0
+
+    with patch("scherlok.cli.shutil.which", return_value="/usr/local/bin/dbt"), \
+         patch("scherlok.cli.subprocess.run", fake_run), \
+         patch("scherlok.cli._watch_table", return_value=([], {"row_count": 1})) as mock_watch:
+        result = runner.invoke(
+            app,
+            [
+                "dbt-run-and-watch",
+                "--project-dir", str(project_dir),
+                "--connection-string", "postgresql://u:p@h/d",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert [call.args[2] for call in mock_watch.call_args_list] == ["stg_customers"]
+
+
+@patch("scherlok.cli.get_connector")
+def test_dbt_run_and_watch_dbt_selector_is_not_reinterpreted(
+    mock_get_connector, tmp_path, monkeypatch
+):
+    """The artifact, not a non-literal selector, controls executed models."""
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    project_dir = _copy_project_with_run_results(
+        tmp_path, [_successful_result("model.jaffle_shop.fct_orders")]
+    )
+    fake_conn = MagicMock()
+    fake_conn.connect.return_value = True
+    fake_conn.list_tables.return_value = ["fct_orders"]
+    mock_get_connector.return_value = fake_conn
+    fake_run = MagicMock()
+    fake_run.return_value.returncode = 0
+
+    with patch("scherlok.cli.shutil.which", return_value="/usr/local/bin/dbt"), \
+         patch("scherlok.cli.subprocess.run", fake_run), \
+         patch("scherlok.cli._watch_table", return_value=([], {"row_count": 1})) as mock_watch:
+        result = runner.invoke(
+            app,
+            [
+                "dbt-run-and-watch",
+                "--project-dir", str(project_dir),
+                "--connection-string", "postgresql://u:p@h/d",
+                "--select", "tag:orders",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert [call.args[2] for call in mock_watch.call_args_list] == ["fct_orders"]
+    cmd_args = fake_run.call_args.args[0]
+    assert "tag:orders" in cmd_args
+
+
+@patch("scherlok.cli.get_connector")
+def test_dbt_run_and_watch_empty_execution_set_does_not_profile_manifest(
+    mock_get_connector, tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    project_dir = _copy_project_with_run_results(
+        tmp_path, [_successful_result("model.jaffle_shop.fct_orders", "error")]
+    )
+    fake_run = MagicMock()
+    fake_run.return_value.returncode = 0
+
+    with patch("scherlok.cli.shutil.which", return_value="/usr/local/bin/dbt"), \
+         patch("scherlok.cli.subprocess.run", fake_run), \
+         patch("scherlok.cli._watch_table") as mock_watch:
+        result = runner.invoke(
+            app,
+            [
+                "dbt-run-and-watch",
+                "--project-dir", str(project_dir),
+                "--connection-string", "postgresql://u:p@h/d",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "No successfully executed dbt models" in result.output
+    mock_get_connector.assert_not_called()
+    mock_watch.assert_not_called()
+
+
+def test_dbt_run_and_watch_json_empty_execution_set_is_parseable(tmp_path):
+    project_dir = _copy_project_with_run_results(
+        tmp_path, [_successful_result("model.jaffle_shop.fct_orders", "no-op")]
+    )
+    fake_run = MagicMock()
+    fake_run.return_value.returncode = 0
+
+    with patch("scherlok.cli.shutil.which", return_value="/usr/local/bin/dbt"), \
+         patch("scherlok.cli.subprocess.run", fake_run):
+        result = runner.invoke(
+            app,
+            [
+                "dbt-run-and-watch",
+                "--project-dir", str(project_dir),
+                "--output", "json",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["models"] == []
+    assert payload["summary"] == {
+        "profiled": 0,
+        "anomalies": 0,
+        "critical": 0,
+        "warning": 0,
+    }
+
+
+@pytest.mark.parametrize("artifact_kind", ["missing", "malformed"])
+def test_dbt_run_and_watch_artifact_failure_skips_profiling(
+    tmp_path, artifact_kind
+):
+    project_dir = _copy_project_with_run_results(tmp_path, [])
+    artifact_path = project_dir / "target" / "run_results.json"
+    if artifact_kind == "missing":
+        artifact_path.unlink()
+    else:
+        artifact_path.write_text("{not json", encoding="utf-8")
+    fake_run = MagicMock()
+    fake_run.return_value.returncode = 0
+
+    with patch("scherlok.cli.shutil.which", return_value="/usr/local/bin/dbt"), \
+         patch("scherlok.cli.subprocess.run", fake_run), \
+         patch("scherlok.cli._dbt_impl") as mock_impl:
+        result = runner.invoke(
+            app,
+            [
+                "dbt-run-and-watch",
+                "--project-dir", str(project_dir),
+                "--connection-string", "postgresql://u:p@h/d",
+            ],
+        )
+
+    assert result.exit_code == 1
+    assert "run_results.json" in result.output
+    mock_impl.assert_not_called()
+
+
+def test_dbt_run_and_watch_json_artifact_failure_is_parseable(tmp_path):
+    project_dir = _copy_project_with_run_results(tmp_path, [])
+    (project_dir / "target" / "run_results.json").unlink()
+    fake_run = MagicMock()
+    fake_run.return_value.returncode = 0
+
+    with patch("scherlok.cli.shutil.which", return_value="/usr/local/bin/dbt"), \
+         patch("scherlok.cli.subprocess.run", fake_run), \
+         patch("scherlok.cli._dbt_impl") as mock_impl:
+        result = runner.invoke(
+            app,
+            [
+                "dbt-run-and-watch",
+                "--project-dir", str(project_dir),
+                "--output", "json",
+            ],
+        )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["returncode"] == 1
+    assert "run_results.json" in payload["error"]
+    mock_impl.assert_not_called()
+
+
+@patch("scherlok.cli.get_connector")
+def test_dbt_run_and_watch_keeps_explicit_sources_and_snapshots(
+    mock_get_connector, tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    project_dir = _copy_project_with_run_results(
+        tmp_path,
+        [_successful_result("model.jaffle_shop.stg_customers")],
+        include_snapshot=True,
+    )
+    fake_conn = MagicMock()
+    fake_conn.connect.return_value = True
+    fake_conn.list_tables.return_value = ["stg_customers", "raw_payments", "orders_snapshot"]
+    mock_get_connector.return_value = fake_conn
+    fake_run = MagicMock()
+    fake_run.return_value.returncode = 0
+
+    with patch("scherlok.cli.shutil.which", return_value="/usr/local/bin/dbt"), \
+         patch("scherlok.cli.subprocess.run", fake_run), \
+         patch("scherlok.cli._watch_table", return_value=([], {"row_count": 1})) as mock_watch:
+        result = runner.invoke(
+            app,
+            [
+                "dbt-run-and-watch",
+                "--project-dir", str(project_dir),
+                "--connection-string", "postgresql://u:p@h/d",
+                "--include-sources",
+                "--include-snapshots",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert {call.args[2] for call in mock_watch.call_args_list} == {
+        "stg_customers", "raw_payments", "orders_snapshot"
+    }
+
+
 def test_dbt_run_and_watch_calls_scherlok_dbt_on_success():
     """When `dbt run` succeeds, `_dbt_impl` must be invoked with all required flags."""
     fake_run = MagicMock()
@@ -127,10 +378,16 @@ def test_dbt_run_and_watch_calls_scherlok_dbt_on_success():
     # at runtime. Locking these in here so a future regression surfaces.
     for required in (
         "profiles_dir", "select", "include_sources", "include_snapshots",
-        "webhook", "email", "json_mode", "show_lineage",
+        "webhook", "email", "json_mode", "show_lineage", "executed_model_ids",
     ):
         assert required in kwargs, f"_dbt_impl call missing kwarg: {required}"
     assert kwargs["json_mode"] is False  # default --output is 'text'
+    assert kwargs["executed_model_ids"] == {
+        "model.jaffle_shop.stg_customers",
+        "model.jaffle_shop.stg_orders",
+        "model.jaffle_shop.fct_orders",
+        "model.jaffle_shop.dim_customers_inc",
+    }
 
 
 @patch("scherlok.cli.get_connector")

--- a/tests/test_dbt_run_and_watch.py
+++ b/tests/test_dbt_run_and_watch.py
@@ -9,6 +9,7 @@ import pytest
 from typer.testing import CliRunner
 
 from scherlok.cli import app
+from scherlok.dbt.run_results import _validated_results
 
 runner = CliRunner()
 FIXTURES = Path(__file__).parent / "fixtures" / "dbt"
@@ -146,9 +147,14 @@ def test_dbt_run_and_watch_profiles_only_successful_models(
     fake_run = MagicMock()
     fake_run.return_value.returncode = 0
 
-    with patch("scherlok.cli.shutil.which", return_value="/usr/local/bin/dbt"), \
-         patch("scherlok.cli.subprocess.run", fake_run), \
-         patch("scherlok.cli._watch_table", return_value=([], {"row_count": 1})) as mock_watch:
+    with (
+        patch("scherlok.cli.shutil.which", return_value="/usr/local/bin/dbt"),
+        patch("scherlok.cli.subprocess.run", fake_run),
+        patch("scherlok.cli._watch_table", return_value=([], {"row_count": 1})) as mock_watch,
+        patch(
+            "scherlok.dbt.run_results._validated_results", wraps=_validated_results
+        ) as mock_validate,
+    ):
         result = runner.invoke(
             app,
             [
@@ -160,6 +166,7 @@ def test_dbt_run_and_watch_profiles_only_successful_models(
 
     assert result.exit_code == 0, result.output
     assert [call.args[2] for call in mock_watch.call_args_list] == ["stg_customers"]
+    assert mock_validate.call_count == 1
 
 
 @patch("scherlok.cli.get_connector")

--- a/tests/test_dbt_run_results.py
+++ b/tests/test_dbt_run_results.py
@@ -1,0 +1,70 @@
+"""Tests for dbt run_results.json parsing."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scherlok.dbt.run_results import load_run_results, successful_model_unique_ids
+
+
+def _write_run_results(project_dir: Path, value: object) -> Path:
+    target_dir = project_dir / "target"
+    target_dir.mkdir()
+    path = target_dir / "run_results.json"
+    path.write_text(json.dumps(value), encoding="utf-8")
+    return path
+
+
+def test_load_run_results_valid_artifact(tmp_path):
+    artifact = {"metadata": {"dbt_version": "1.8.0"}, "results": []}
+    _write_run_results(tmp_path, artifact)
+
+    assert load_run_results(tmp_path) == artifact
+
+
+def test_load_run_results_missing_file(tmp_path):
+    with pytest.raises(FileNotFoundError, match="run_results.json not found"):
+        load_run_results(tmp_path)
+
+
+def test_load_run_results_malformed_json(tmp_path):
+    target_dir = tmp_path / "target"
+    target_dir.mkdir()
+    (target_dir / "run_results.json").write_text("{not json", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Malformed run_results.json"):
+        load_run_results(tmp_path)
+
+
+def test_successful_model_unique_ids_extracts_only_successful_models():
+    run_results = {
+        "results": [
+            {"unique_id": "model.demo.orders", "status": "success"},
+            {"unique_id": "model.demo.customers", "status": "error"},
+            {"unique_id": "model.demo.payments", "status": "skipped"},
+            {"unique_id": "model.demo.products", "status": "partial success"},
+            {"unique_id": "model.demo.inventory", "status": "no-op"},
+            {"unique_id": "seed.demo.raw_orders", "status": "success"},
+            {"unique_id": "test.demo.orders", "status": "success"},
+            {"unique_id": "snapshot.demo.orders", "status": "success"},
+        ]
+    }
+
+    assert successful_model_unique_ids(run_results) == {"model.demo.orders"}
+
+
+@pytest.mark.parametrize(
+    "artifact",
+    [
+        [],
+        {"metadata": {}},
+        {"results": {}},
+        {"results": ["not an object"]},
+        {"results": [{"status": "success"}]},
+        {"results": [{"unique_id": "model.demo.orders"}]},
+    ],
+)
+def test_successful_model_unique_ids_rejects_unusable_structure(artifact):
+    with pytest.raises(ValueError, match="Invalid run_results.json"):
+        successful_model_unique_ids(artifact)


### PR DESCRIPTION
## Summary

Closes #69.

`dbt-run-and-watch` now consumes the successful model execution results from the `target/run_results.json` generated by the `dbt run` it just executed. It correlates result entries to manifest nodes by `unique_id`, so partial dbt selections and selector expressions profile only models that actually succeeded.

## Design rationale

- Added `scherlok.dbt.run_results` as a small standard-library artifact seam that validates the JSON shape and extracts only `status == success` `model.*` IDs.
- Added an explicit keyword-only `executed_model_ids` boundary to `_dbt_impl`; `None` preserves standalone `scherlok dbt` behavior while an empty set means zero successful models and never falls back to the manifest.
- The wrapper still forwards `--select` unchanged to the real `dbt run`; it does not reimplement dbt selector semantics.
- Explicit `--include-sources` and `--include-snapshots` remain independently supported and are not filtered as model execution results.
- Missing, malformed, or structurally unusable `run_results.json` fails clearly in text mode and emits a parseable JSON error document in `--output json` mode.
- Relation matching remains unchanged and is intentionally left for #68.

## Test evidence

- Focused dbt/parser/manifest suite: `55 passed`
- `ruff check src/ tests/`: passed
- `git diff --check`: passed
- Full suite: `367 passed, 1 failed`
- The one failure is the unrelated existing Windows DuckDB URL test (`tests/test_duckdb.py::test_connect_failure_sets_last_error`), which constructs `duckdb://C:\\...` and raises before the assertion; no connector files were changed.

No real dbt/Postgres smoke run was attempted: `dbt` is unavailable locally, and the required smoke services/dependencies are not already set up. `examples/dbt_smoke/` was inspected and no environment was changed to force it.