### PR TITLE
fix(cli): keep dbt JSON stdout clean on early exits

### DIFF
--- a/src/scherlok/cli.py
+++ b/src/scherlok/cli.py
@@ -88,10 +88,10 @@ def _get_connector_or_exit() -> object:
 
 def _print_connect_failure(connector: object) -> None:
     """Render a 'failed to connect' header plus connector.last_error if available."""
-    console.print("[red]Failed to connect to the database.[/red]")
+    out_error("[red]Failed to connect to the database.[/red]")
     err = getattr(connector, "last_error", None)
     if err:
-        console.print(f"  [dim]{err}[/dim]")
+        out_error(f"  [dim]{err}[/dim]")
 
 
 CONNECT_EXAMPLES: list[tuple[str, str]] = [
@@ -638,7 +638,7 @@ def _dbt_impl(
     try:
         manifest = load_manifest(project_dir)
     except (FileNotFoundError, ValueError) as exc:
-        console.print(f"[red]{exc}[/red]")
+        out_error(f"[red]{exc}[/red]")
         raise typer.Exit(code=1) from exc
 
     adapter = manifest.get("metadata", {}).get("adapter_type", "?")
@@ -666,7 +666,7 @@ def _dbt_impl(
                 if n.resource_type == "model" or n.name in wanted or n.identifier in wanted
             ]
         if not nodes and executed_model_ids is None:
-            console.print(f"[red]No models matched --select {list(wanted)}.[/red]")
+            out_error(f"[red]No models matched --select {list(wanted)}.[/red]")
             raise typer.Exit(code=1)
 
     if not nodes:
@@ -691,7 +691,7 @@ def _dbt_impl(
             else:
                 out_info(f"[yellow]{message}[/yellow]")
         else:
-            console.print("[yellow]No materialized models found in manifest.[/yellow]")
+            out_error("[yellow]No materialized models found in manifest.[/yellow]")
         raise typer.Exit(code=0)
 
     # 2. Resolve connection string
@@ -703,7 +703,7 @@ def _dbt_impl(
                 project_dir, profiles_dir=profiles_dir, target=target
             )
         except ProfileResolutionError as exc:
-            console.print(f"[red]{exc}[/red]")
+            out_error(f"[red]{exc}[/red]")
             raise typer.Exit(code=1) from exc
 
     cfg = ScherlokConfig.load()

--- a/tests/test_dbt_cli.py
+++ b/tests/test_dbt_cli.py
@@ -27,6 +27,22 @@ def test_dbt_missing_manifest():
     assert "manifest.json not found" in result.output
 
 
+def test_dbt_output_json_missing_manifest_keeps_stdout_clean(tmp_path):
+    """A missing manifest error is routed to stderr in JSON mode."""
+    result = runner.invoke(
+        app,
+        [
+            "dbt",
+            "--project-dir", str(tmp_path / "missing-project"),
+            "--output", "json",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    assert "manifest.json not found" in result.stderr
+
+
 def test_dbt_select_filter_no_match():
     """--select with a name that doesn't exist exits with a clear error."""
     result = runner.invoke(
@@ -40,6 +56,103 @@ def test_dbt_select_filter_no_match():
     )
     assert result.exit_code == 1
     assert "No models matched" in result.output
+
+
+def test_dbt_output_json_select_filter_no_match_keeps_stdout_clean():
+    """An unmatched --select error is routed to stderr in JSON mode."""
+    result = runner.invoke(
+        app,
+        [
+            "dbt",
+            "--project-dir", str(PG_PROJECT),
+            "--connection-string", "postgresql://u:p@host/db",
+            "--select", "ghost_model",
+            "--output", "json",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    assert "No models matched" in result.stderr
+
+
+def test_dbt_output_json_no_materialized_models_keeps_stdout_clean(tmp_path):
+    """A manifest without physical models warns on stderr but still exits 0."""
+    project_dir = tmp_path / "project"
+    target_dir = project_dir / "target"
+    target_dir.mkdir(parents=True)
+    (target_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "metadata": {
+                    "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
+                    "adapter_type": "postgres",
+                },
+                "nodes": {
+                    "model.demo.ephemeral": {
+                        "resource_type": "model",
+                        "name": "ephemeral",
+                        "config": {"materialized": "ephemeral"},
+                    }
+                },
+                "sources": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        ["dbt", "--project-dir", str(project_dir), "--output", "json"],
+    )
+
+    assert result.exit_code == 0
+    assert result.stdout == ""
+    assert "No materialized models found" in result.stderr
+
+
+def test_dbt_output_json_profile_resolution_failure_keeps_stdout_clean(tmp_path):
+    """A profile-resolution error is routed to stderr in JSON mode."""
+    result = runner.invoke(
+        app,
+        [
+            "dbt",
+            "--project-dir", str(PG_PROJECT),
+            "--profiles-dir", str(tmp_path / "missing-profiles"),
+            "--output", "json",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    assert "profiles.yml not found" in result.stderr
+
+
+@patch("scherlok.cli.get_connector")
+def test_dbt_output_json_connector_failure_keeps_stdout_clean(
+    mock_get_connector, tmp_path, monkeypatch
+):
+    """Connector failure output, including last_error, is routed to stderr."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    fake = MagicMock()
+    fake.connect.return_value = False
+    fake.last_error = "connection refused: test database"
+    mock_get_connector.return_value = fake
+
+    result = runner.invoke(
+        app,
+        [
+            "dbt",
+            "--project-dir", str(PG_PROJECT),
+            "--connection-string", "postgresql://u:p@host/db",
+            "--output", "json",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    assert "Failed to connect to the database." in result.stderr
+    assert "connection refused: test database" in result.stderr
 
 
 @patch("scherlok.cli.get_connector")


### PR DESCRIPTION
## Summary

Closes #67.

Route early scherlok dbt errors and warnings through the existing scherlok.output.error abstraction so --output json keeps stdout machine-clean. _print_connect_failure() now routes both its header and connector last_error through the same abstraction.

This intentionally does not add JSON error documents, change output.py, alter adapter/relation matching, or rely on the unsupported-adapter allowlist.

## Validation

- uv run --extra dev pytest -q --basetemp C:\\Users\\bfera\\AppData\\Local\\Temp\\opencode\\scherlok-pytest tests/test_dbt_cli.py: 18 passed
- All dbt tests (	est_dbt_cli.py, 	est_dbt_manifest.py, 	est_dbt_profiles.py, 	est_dbt_lineage.py, 	est_dbt_run_results.py, 	est_dbt_run_and_watch.py): 93 passed
- uv run --extra dev ruff check src/ tests/: passed
- git diff --check: passed
- Full suite: 372 passed, 1 failed

The full-suite failure is the unrelated existing Windows DuckDB URL test 	ests/test_duckdb.py::test_connect_failure_sets_last_error; no connector files were changed.