### PR TITLE
feat(dbt): make lineage alerts exposure-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **`scherlok dbt-run-and-watch --output json`** — the wrapper now accepts the same `--output json` flag as `scherlok dbt`, so CI users get the wrapper's convenience and a machine-readable stdout payload in one step. `dbt run`'s own stdout is rerouted to stderr in JSON mode so it never mixes with the payload; if `dbt run` fails, stdout gets a small JSON error document (`project_dir`, `error`, `returncode`) instead of plain text. ([#47](https://github.com/rbmuller/scherlok/issues/47))
 - **Targeted `dbt-run-and-watch` profiling** — after a successful `dbt run`, the wrapper reads `target/run_results.json` and profiles only successful model nodes from that invocation. Missing or malformed artifacts fail clearly rather than falling back to the full manifest. ([#69](https://github.com/rbmuller/scherlok/issues/69))
+- **Exposure-aware dbt lineage in anomaly alerts** — downstream models remain identified separately from dbt exposures, whose labels and owner information are surfaced in the existing alert message without changing notification routing. ([#70](https://github.com/rbmuller/scherlok/issues/70))
 
 ## [0.9.0] — 2026-08-10
 

--- a/src/scherlok/cli.py
+++ b/src/scherlok/cli.py
@@ -1,12 +1,16 @@
 """CLI entry point for Scherlok. Built with Typer and Rich."""
 
+from __future__ import annotations
+
 import json
 import shutil
 import subprocess
 import sys
 import time
+from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import typer
 from rich.console import Console
@@ -38,6 +42,10 @@ from scherlok.profiler.volume import profile_volume
 from scherlok.service import profile_and_detect
 from scherlok.store.remote import sync_context
 from scherlok.store.sqlite import ProfileStore
+
+if TYPE_CHECKING:
+    from scherlok.dbt.manifest import DbtExposure
+
 
 app = typer.Typer(
     name="scherlok",
@@ -628,6 +636,7 @@ def _dbt_impl(
         DbtNode,
         ProfileResolutionError,
         build_dependency_graph,
+        discover_exposures,
         discover_models,
         discover_sources,
         load_manifest,
@@ -740,6 +749,7 @@ def _dbt_impl(
 
     # 4. Build lineage graph once for downstream enrichment + --show-lineage
     lineage_graph = build_dependency_graph(manifest)
+    exposures = discover_exposures(manifest)
 
     # 5. Per-model investigate + watch
     from scherlok.config import PROFILES_DB
@@ -753,7 +763,9 @@ def _dbt_impl(
             # Enrich each anomaly's message with downstream-impact info so the
             # downstream context follows the anomaly through prints, JSON, and
             # alerter payloads alike.
-            _enrich_anomalies_with_lineage(table_anomalies, node.unique_id, lineage_graph)
+            _enrich_anomalies_with_lineage(
+                table_anomalies, node.unique_id, lineage_graph, exposures
+            )
             all_anomalies.extend(table_anomalies)
             if explain and table_anomalies:
                 # Upstream parents feed the explainer bundle: broken parents
@@ -1059,14 +1071,16 @@ def _print_dbt_model_result(
 
 
 def _enrich_anomalies_with_lineage(
-    anomalies: list[dict], unique_id: str, graph: dict[str, list[str]]
+    anomalies: list[dict],
+    unique_id: str,
+    graph: dict[str, list[str]],
+    exposures: list[DbtExposure] | None = None,
 ) -> None:
     """Append a downstream-impact note to each anomaly's message in place.
 
-    The note quotes up to 3 downstream model names plus an overflow count
-    so the alerter payload stays readable while still hinting at scale.
-    No-op when the node has no downstream consumers — callers won't be
-    flooded with `Affects 0 downstream models` lines on leaf marts.
+    Resource types are classified for presentation only. The full transitive
+    graph is still traversed so tests and other intermediate resources cannot
+    hide an exposure farther downstream.
     """
     from scherlok.dbt import display_name as _display_name
     from scherlok.dbt import downstream_of as _downstream_of
@@ -1074,16 +1088,59 @@ def _enrich_anomalies_with_lineage(
     downstream = _downstream_of(graph, unique_id)
     if not downstream:
         return
-    names = [_display_name(uid) for uid in downstream]
-    preview = ", ".join(names[:3])
-    overflow = f" (+{len(names) - 3} more)" if len(names) > 3 else ""
-    plural = "s" if len(names) != 1 else ""
-    suffix = (
-        f" · Affects {len(names)} downstream model{plural}: {preview}{overflow}"
-    )
+
+    model_ids = [uid for uid in downstream if uid.split(".", 1)[0] == "model"]
+    exposure_ids = [uid for uid in downstream if uid.split(".", 1)[0] == "exposure"]
+    suffixes: list[str] = []
+    if model_ids:
+        model_names = [_display_name(uid) for uid in model_ids]
+        preview = ", ".join(model_names[:3])
+        overflow = f" (+{len(model_names) - 3} more)" if len(model_names) > 3 else ""
+        plural = "s" if len(model_names) != 1 else ""
+        suffixes.append(
+            f"Affects {len(model_names)} downstream model{plural}: {preview}{overflow}"
+        )
+
+    exposure_by_id = {
+        exposure.unique_id: exposure for exposure in exposures or []
+    }
+    if exposure_ids:
+        exposure_names = [
+            _format_exposure(uid, exposure_by_id.get(uid), _display_name)
+            for uid in exposure_ids
+        ]
+        preview = ", ".join(exposure_names[:3])
+        overflow = f" (+{len(exposure_names) - 3} more)" if len(exposure_names) > 3 else ""
+        plural = "s" if len(exposure_names) != 1 else ""
+        suffixes.append(
+            f"Downstream exposure{plural}: {preview}{overflow}"
+        )
+
+    if not suffixes:
+        return
+    suffix = " · " + " · ".join(suffixes)
     for a in anomalies:
         msg = a.get("message", "")
         a["message"] = f"{msg}{suffix}"
+
+
+def _format_exposure(
+    unique_id: str,
+    exposure: DbtExposure | None,
+    fallback_name: Callable[[str], str],
+) -> str:
+    """Render one exposure with its useful owner information."""
+    if exposure is None:
+        label = fallback_name(unique_id)
+        return label
+
+    label = exposure.display_name
+    label = label or fallback_name(unique_id)
+    if exposure.owner_emails:
+        return f"{label} (owner: {', '.join(exposure.owner_emails)})"
+    if exposure.owner_name:
+        return f"{label} (owner: {exposure.owner_name})"
+    return label
 
 
 def _upstream_preview(graph: dict[str, list[str]], unique_id: str) -> list[str]:

--- a/src/scherlok/dbt/README.md
+++ b/src/scherlok/dbt/README.md
@@ -127,6 +127,14 @@ When an anomaly fires, the message is enriched with downstream impact so the ale
 ✗ stg_customers  CRITICAL: Row count dropped 60.0% (1000 → 400) · Affects 2 downstream models: fct_orders, dim_customers_inc
 ```
 
+When the manifest declares dbt exposures, exposure descendants are shown separately from models. The exposure label is preferred over its manifest name, and useful owner information is included when present:
+
+```
+✗ stg_customers  CRITICAL: Row count dropped 42% · Affects 2 downstream models: fct_orders, dim_customers_inc · Downstream exposure: Revenue Dashboard (owner: analytics-team@company.com)
+```
+
+Lineage continues to come from `parent_map`, so tests and other non-model resources may remain traversal nodes without being mislabeled as downstream models. Exposure owners are surfaced in the existing alert message only; Scherlok does not automatically notify those addresses unless the configured alert destination already reaches them. Multiple exposures use the same bounded preview convention as downstream models.
+
 Leaf marts (no descendants) get no suffix.
 
 ## What's coming next

--- a/src/scherlok/dbt/__init__.py
+++ b/src/scherlok/dbt/__init__.py
@@ -12,14 +12,23 @@ from scherlok.dbt.lineage import (
     render_lineage_tree,
     upstream_of,
 )
-from scherlok.dbt.manifest import DbtNode, discover_models, discover_sources, load_manifest
+from scherlok.dbt.manifest import (
+    DbtExposure,
+    DbtNode,
+    discover_exposures,
+    discover_models,
+    discover_sources,
+    load_manifest,
+)
 from scherlok.dbt.profiles import ProfileResolutionError, resolve_connection_string
 from scherlok.dbt.run_results import load_run_results, successful_model_unique_ids
 
 __all__ = [
     "DbtNode",
+    "DbtExposure",
     "ProfileResolutionError",
     "build_dependency_graph",
+    "discover_exposures",
     "discover_models",
     "discover_sources",
     "display_name",

--- a/src/scherlok/dbt/manifest.py
+++ b/src/scherlok/dbt/manifest.py
@@ -1,4 +1,4 @@
-"""Parse dbt's target/manifest.json to discover models and sources."""
+"""Parse dbt's target/manifest.json to discover models, sources, and exposures."""
 
 from __future__ import annotations
 
@@ -24,6 +24,23 @@ class DbtNode:
     identifier: str  # alias for models, identifier for sources
     relation_name: str | None  # quoted FQN as dbt produced it (may be None)
     adapter: str  # postgres / bigquery / snowflake
+
+
+@dataclass(frozen=True)
+class DbtExposure:
+    """A dbt exposure that consumes one or more project resources."""
+
+    unique_id: str
+    name: str
+    label: str | None
+    exposure_type: str
+    owner_name: str | None
+    owner_emails: tuple[str, ...]
+
+    @property
+    def display_name(self) -> str:
+        """Return the human-readable label, falling back to the manifest name."""
+        return self.label or self.name
 
 
 def load_manifest(project_dir: str | Path) -> dict:
@@ -137,6 +154,66 @@ def discover_sources(manifest: dict) -> list[DbtNode]:
         )
 
     return sources
+
+
+def discover_exposures(manifest: dict) -> list[DbtExposure]:
+    """Return exposures declared in the manifest.
+
+    dbt currently emits ``owner.email`` as a string, but accepting a list here
+    keeps schema-shape handling at the manifest boundary.
+    """
+    exposures_dict = manifest.get("exposures", {})
+    if not isinstance(exposures_dict, dict):
+        return []
+    exposures: list[DbtExposure] = []
+
+    for unique_id, raw_exposure in exposures_dict.items():
+        if not isinstance(raw_exposure, dict):
+            continue
+        owner = raw_exposure.get("owner")
+        if not isinstance(owner, dict):
+            owner = {}
+        email_value = owner.get("email")
+        if email_value is None:
+            email_value = owner.get("emails")
+
+        exposures.append(
+            DbtExposure(
+                unique_id=unique_id,
+                name=_optional_text(raw_exposure.get("name")) or "",
+                label=_optional_text(raw_exposure.get("label")),
+                exposure_type=_optional_text(raw_exposure.get("type")) or "",
+                owner_name=_optional_text(owner.get("name")),
+                owner_emails=_normalize_owner_emails(email_value),
+            )
+        )
+
+    return exposures
+
+
+def _optional_text(value: object) -> str | None:
+    """Return stripped text or None for absent/non-text manifest values."""
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value or None
+
+
+def _normalize_owner_emails(value: object) -> tuple[str, ...]:
+    """Normalize one or many owner email values into deterministic output."""
+    if isinstance(value, str):
+        values = (value,)
+    elif isinstance(value, (list, tuple)):
+        values = value
+    else:
+        values = ()
+
+    emails = {
+        email.strip()
+        for email in values
+        if isinstance(email, str) and email.strip()
+    }
+    return tuple(sorted(emails, key=str.casefold))
 
 
 def _parse_manifest_version(manifest: dict) -> int:

--- a/tests/fixtures/dbt/jaffle_shop_postgres/target/manifest.json
+++ b/tests/fixtures/dbt/jaffle_shop_postgres/target/manifest.json
@@ -110,6 +110,18 @@
       "relation_name": "\"jaffle_db\".\"raw\".\"raw_payments\""
     }
   },
+  "exposures": {
+    "exposure.jaffle_shop.revenue_dashboard": {
+      "resource_type": "exposure",
+      "name": "revenue_dashboard",
+      "label": "Revenue Dashboard",
+      "type": "dashboard",
+      "owner": {
+        "name": "Analytics Team",
+        "email": "analytics-team@company.com"
+      }
+    }
+  },
   "parent_map": {
     "model.jaffle_shop.stg_customers": [
       "seed.jaffle_shop.raw_customers"
@@ -130,6 +142,9 @@
     "test.jaffle_shop.unique_stg_customers_id.abc123": [
       "model.jaffle_shop.stg_customers"
     ],
+    "exposure.jaffle_shop.revenue_dashboard": [
+      "model.jaffle_shop.dim_customers_inc"
+    ],
     "seed.jaffle_shop.raw_customers": [],
     "source.jaffle_shop.raw.payments": []
   },
@@ -146,8 +161,11 @@
       "model.jaffle_shop.fct_orders"
     ],
     "model.jaffle_shop.fct_orders": [],
-    "model.jaffle_shop.dim_customers_inc": [],
+    "model.jaffle_shop.dim_customers_inc": [
+      "exposure.jaffle_shop.revenue_dashboard"
+    ],
     "test.jaffle_shop.unique_stg_customers_id.abc123": [],
+    "exposure.jaffle_shop.revenue_dashboard": [],
     "seed.jaffle_shop.raw_customers": [
       "model.jaffle_shop.stg_customers"
     ],

--- a/tests/test_dbt_cli.py
+++ b/tests/test_dbt_cli.py
@@ -6,7 +6,8 @@ from unittest.mock import MagicMock, patch
 
 from typer.testing import CliRunner
 
-from scherlok.cli import app
+from scherlok.cli import _enrich_anomalies_with_lineage, app
+from scherlok.dbt.manifest import DbtExposure
 
 runner = CliRunner()
 FIXTURES = Path(__file__).parent / "fixtures" / "dbt"
@@ -295,6 +296,10 @@ def test_dbt_output_json_emits_parseable_object(mock_get_connector, tmp_path, mo
     assert set(first.keys()) >= {"name", "physical", "resource_type", "row_count", "anomalies"}
     assert first["anomalies"][0]["severity"] == "CRITICAL"
     assert first["anomalies"][0]["type"] == "volume_drop"
+    first_message = first["anomalies"][0]["message"]
+    assert "Affects 2 downstream models: fct_orders, dim_customers_inc" in first_message
+    assert "Downstream exposure: Revenue Dashboard" in first_message
+    assert "analytics-team@company.com" in first_message
     summary = payload["summary"]
     assert set(summary.keys()) >= {"profiled", "anomalies", "critical", "warning"}
     assert summary["profiled"] == 4
@@ -456,8 +461,130 @@ def test_dbt_anomaly_message_enriched_with_downstream(mock_get_connector, tmp_pa
     assert result.exit_code == 1
     # Message must be enriched in place (so alerter payloads carry the same info)
     assert "Affects" in anomaly["message"]
-    assert "downstream model" in anomaly["message"]
+    assert "Affects 2 downstream models: fct_orders, dim_customers_inc" in anomaly["message"]
+    assert (
+        "Downstream exposure: Revenue Dashboard (owner: analytics-team@company.com)"
+        in anomaly["message"]
+    )
     assert "fct_orders" in anomaly["message"]
+    assert "unique_stg_customers_id" not in anomaly["message"]
+
+
+def test_dbt_anomaly_message_uses_exposure_name_and_owner_name_fallback():
+    from scherlok.detector.severity import Severity
+
+    anomaly = {
+        "table": "source_table",
+        "severity": Severity.WARNING,
+        "type": "volume_drop",
+        "message": "Row count dropped",
+    }
+    graph = {
+        "model.demo.source": [],
+        "test.demo.validation": ["model.demo.source"],
+        "exposure.demo.dashboard": ["test.demo.validation"],
+    }
+    exposure = DbtExposure(
+        unique_id="exposure.demo.dashboard",
+        name="dashboard",
+        label=None,
+        exposure_type="dashboard",
+        owner_name="Analytics Team",
+        owner_emails=(),
+    )
+
+    _enrich_anomalies_with_lineage(
+        [anomaly], "model.demo.source", graph, [exposure]
+    )
+
+    assert anomaly["message"] == (
+        "Row count dropped · Downstream exposure: dashboard (owner: Analytics Team)"
+    )
+    assert "validation" not in anomaly["message"]
+
+
+def test_dbt_anomaly_message_bounds_multiple_exposures_and_renders_emails():
+    from scherlok.detector.severity import Severity
+
+    source_id = "model.demo.source"
+    exposure_ids = [f"exposure.demo.dashboard_{i}" for i in range(4)]
+    graph = {source_id: []}
+    for exposure_id in exposure_ids:
+        graph[exposure_id] = [source_id]
+    exposures = [
+        DbtExposure(
+            unique_id=exposure_id,
+            name=exposure_id.rsplit(".", 1)[-1],
+            label=f"Dashboard {i}",
+            exposure_type="dashboard",
+            owner_name=None,
+            owner_emails=(f"owner{i}@example.com", f"backup{i}@example.com"),
+        )
+        for i, exposure_id in enumerate(exposure_ids)
+    ]
+    anomaly = {
+        "table": "source_table",
+        "severity": Severity.CRITICAL,
+        "type": "volume_drop",
+        "message": "Row count dropped",
+    }
+
+    _enrich_anomalies_with_lineage([anomaly], source_id, graph, exposures)
+
+    expected = (
+        "Downstream exposures: Dashboard 0 (owner: owner0@example.com, backup0@example.com), "
+        "Dashboard 1 (owner: owner1@example.com, backup1@example.com), "
+        "Dashboard 2 (owner: owner2@example.com, backup2@example.com) (+1 more)"
+    )
+    assert expected in anomaly["message"]
+    assert "Dashboard 3" not in anomaly["message"]
+
+
+@patch("scherlok.cli.get_connector")
+@patch("scherlok.cli.send_webhook")
+@patch("scherlok.cli.send_email_alert")
+def test_dbt_enriched_message_reaches_existing_alert_sinks(
+    mock_send_email, mock_send_webhook, mock_get_connector, tmp_path, monkeypatch
+):
+    from scherlok.detector.severity import Severity
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    fake = MagicMock()
+    fake.connect.return_value = True
+    fake.list_tables.return_value = [
+        "stg_customers", "stg_orders", "fct_orders", "dim_customers_inc",
+    ]
+    mock_get_connector.return_value = fake
+    anomaly = {
+        "table": "stg_customers",
+        "severity": Severity.CRITICAL,
+        "type": "volume_drop",
+        "message": "Row count dropped 60%",
+    }
+
+    with patch("scherlok.cli._watch_table") as mock_watch:
+        mock_watch.side_effect = [
+            ([anomaly], {"row_count": 40}),
+            ([], {"row_count": 100}),
+            ([], {"row_count": 200}),
+            ([], {"row_count": 300}),
+        ]
+        result = runner.invoke(
+            app,
+            [
+                "dbt",
+                "--project-dir", str(PG_PROJECT),
+                "--connection-string", "postgresql://u:p@host/db",
+                "--webhook", "https://alerts.example.com/hook",
+                "--email", "on-call@example.com",
+            ],
+        )
+
+    assert result.exit_code == 1
+    webhook_anomalies = mock_send_webhook.call_args.args[1]
+    email_anomalies = mock_send_email.call_args.args[1]
+    assert webhook_anomalies[0]["message"] == anomaly["message"]
+    assert email_anomalies[0]["message"] == anomaly["message"]
 
 
 @patch("scherlok.cli.get_connector")

--- a/tests/test_dbt_lineage.py
+++ b/tests/test_dbt_lineage.py
@@ -110,9 +110,12 @@ def test_downstream_of_excludes_self_under_cycle():
 def test_downstream_of_root_walks_full_descent(graph):
     desc = downstream_of(graph, "seed.jaffle_shop.raw_customers")
     # raw_customers -> stg_customers -> {fct_orders, dim_customers_inc, test}
+    # dim_customers_inc -> revenue_dashboard exposure
     assert "model.jaffle_shop.stg_customers" in desc
     assert "model.jaffle_shop.fct_orders" in desc
     assert "model.jaffle_shop.dim_customers_inc" in desc
+    assert "test.jaffle_shop.unique_stg_customers_id.abc123" in desc
+    assert "exposure.jaffle_shop.revenue_dashboard" in desc
 
 
 def test_downstream_of_leaf_returns_empty(graph):

--- a/tests/test_dbt_manifest.py
+++ b/tests/test_dbt_manifest.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from scherlok.dbt.manifest import (
+    discover_exposures,
     discover_models,
     discover_sources,
     load_manifest,
@@ -84,6 +85,80 @@ def test_discover_sources():
 def test_discover_sources_empty_when_none():
     manifest = load_manifest(SF_PROJECT)
     assert discover_sources(manifest) == []
+
+
+def test_discover_exposures_parses_label_type_and_owner_email():
+    manifest = load_manifest(PG_PROJECT)
+    exposures = discover_exposures(manifest)
+
+    assert len(exposures) == 1
+    exposure = exposures[0]
+    assert exposure.unique_id == "exposure.jaffle_shop.revenue_dashboard"
+    assert exposure.name == "revenue_dashboard"
+    assert exposure.label == "Revenue Dashboard"
+    assert exposure.display_name == "Revenue Dashboard"
+    assert exposure.exposure_type == "dashboard"
+    assert exposure.owner_name == "Analytics Team"
+    assert exposure.owner_emails == ("analytics-team@company.com",)
+
+
+def test_discover_exposures_falls_back_to_name_without_label():
+    manifest = {
+        "exposures": {
+            "exposure.demo.named_dashboard": {
+                "name": "named_dashboard",
+                "type": "dashboard",
+            }
+        }
+    }
+
+    exposure = discover_exposures(manifest)[0]
+
+    assert exposure.label is None
+    assert exposure.display_name == "named_dashboard"
+
+
+@pytest.mark.parametrize(
+    ("email", "expected"),
+    [
+        ("owner@example.com", ("owner@example.com",)),
+        (["z@example.com", "a@example.com", "z@example.com"], ("a@example.com", "z@example.com")),
+    ],
+)
+def test_discover_exposures_normalizes_single_and_list_owner_emails(email, expected):
+    manifest = {
+        "exposures": {
+            "exposure.demo.dashboard": {
+                "name": "dashboard",
+                "type": "dashboard",
+                "owner": {"email": email},
+            }
+        }
+    }
+
+    assert discover_exposures(manifest)[0].owner_emails == expected
+
+
+def test_discover_exposures_handles_missing_owner_email():
+    manifest = {
+        "exposures": {
+            "exposure.demo.dashboard": {
+                "name": "dashboard",
+                "type": "dashboard",
+                "owner": {"name": "Analytics Team"},
+            }
+        }
+    }
+
+    exposure = discover_exposures(manifest)[0]
+
+    assert exposure.owner_name == "Analytics Team"
+    assert exposure.owner_emails == ()
+
+
+def test_discover_exposures_empty_when_none():
+    manifest = load_manifest(SF_PROJECT)
+    assert discover_exposures(manifest) == []
 
 
 def test_load_manifest_unsupported_adapter(tmp_path):


### PR DESCRIPTION
Closes #70

## Summary

- Parse top-level dbt manifest exposures into a typed DbtExposure representation and export discover_exposures() through scherlok.dbt.
- Keep parent_map and downstream_of() as the dependency source of truth; classify descendants only when rendering anomaly context.
- Preserve bounded downstream model previews and add separate bounded exposure previews with label/name fallback and owner information.
- Keep enrichment in anomaly message so console, JSON, webhook, email, and stored history continue using the existing message contract.
- Add representative Postgres exposure fixture, focused parser/lineage/CLI/transport regression tests, dbt documentation, and an Unreleased changelog entry.

## Compatibility

- owner.email as a string is supported, list-valued email forms are normalized to deterministic sorted/deduplicated tuples, and owner.emails is accepted defensively.
- Email is rendered when present; owner name is used only when no email is available.
- Projects without exposures and all non-dbt commands retain existing behavior.
- Exposure owners are surfaced only; this change does not automatically notify those addresses. Exposure URLs are intentionally not included in the alert surface for this focused issue.

## Validation

- Focused manifest, lineage, and CLI tests: 62 passed.
- All dbt tests: 102 passed.
- Alerter tests: 30 passed.
- Full suite: 358 passed, 24 skipped.
- Ruff check src/ tests/: passed.

Branch is based on the current upstream main tree, including the already-merged #73 JSON-output fix.