### PR TITLE
perf(dbt): selectively profile null anomaly columns

### DIFF
--- a/models/_models.yml
+++ b/models/_models.yml
@@ -18,8 +18,8 @@ models:
 
   - name: scherlok_column_metrics
     description: >
-      Append-only log of per-column null rates for all monitored models.
-      Used by the null_anomaly test for statistical drift detection.
+      Append-only log of per-column null rates for columns with null_anomaly
+      tests. Used by the null_anomaly test for statistical drift detection.
     columns:
       - name: table_name
         description: Name of the monitored dbt model

--- a/models/scherlok_column_metrics.sql
+++ b/models/scherlok_column_metrics.sql
@@ -7,7 +7,7 @@
 }}
 
 {#
-    Captures per-column null rates for all monitored models.
+    Captures per-column null rates for columns with null_anomaly tests.
     Used by null_anomaly test for statistical drift detection.
 
     Only profiles columns from models that have null_anomaly tests
@@ -18,6 +18,56 @@
 {% set exclude_models = var('scherlok_exclude_models', []) %}
 {% set include_only = var('scherlok_include_models', []) %}
 
+{% set null_anomaly_targets = [] %}
+
+{# Generic test nodes carry the model and column needed for selective profiling. #}
+{% for test_node in graph.nodes.values() %}
+    {% if test_node.resource_type == 'test' %}
+        {% set test_metadata = test_node.test_metadata | default(none, true) %}
+        {% if test_metadata is not none
+            and test_metadata.name | default('', true) == 'null_anomaly' %}
+            {% set test_namespace = test_metadata.namespace | default(none, true) %}
+            {% if test_namespace == 'scherlok'
+                or (test_namespace is none
+                    and test_node.package_name | default('', true) == 'scherlok') %}
+                {% set attached_node_id = test_node.attached_node | default(none, true) %}
+                {% if attached_node_id is none %}
+                    {% set depends_on = test_node.depends_on | default({}, true) %}
+                    {% set dependency_ids = depends_on.nodes | default([], true) %}
+                    {% set model_dependency_ids = [] %}
+                    {% for dependency_id in dependency_ids %}
+                        {% set dependency_node = graph.nodes.get(dependency_id) %}
+                        {% if dependency_node is not none
+                            and dependency_node.resource_type == 'model'
+                            and dependency_node.package_name != 'scherlok' %}
+                            {% do model_dependency_ids.append(dependency_id) %}
+                        {% endif %}
+                    {% endfor %}
+                    {% if model_dependency_ids | length == 1 %}
+                        {% set attached_node_id = model_dependency_ids[0] %}
+                    {% endif %}
+                {% endif %}
+
+                {% set column_name = test_node.column_name | default(none, true) %}
+                {% if column_name is none %}
+                    {% set test_kwargs = test_metadata.kwargs | default({}, true) %}
+                    {% set column_name = test_kwargs.column_name | default(none, true) %}
+                {% endif %}
+
+                {% if attached_node_id is not none and column_name is not none %}
+                    {% set target = {
+                        'model_id': attached_node_id,
+                        'column_name': column_name
+                    } %}
+                    {% if target not in null_anomaly_targets %}
+                        {% do null_anomaly_targets.append(target) %}
+                    {% endif %}
+                {% endif %}
+            {% endif %}
+        {% endif %}
+    {% endif %}
+{% endfor %}
+
 {% set queries = [] %}
 
 {% for node in graph.nodes.values() %}
@@ -27,16 +77,36 @@
         and node.name not in exclude_models
         and (include_only | length == 0 or node.name in include_only) %}
 
-        {% set rel = adapter.get_relation(
-            database=node.database,
-            schema=node.schema,
-            identifier=node.alias or node.name
+        {% set model_id = node.unique_id | default(
+            'model.' ~ node.package_name ~ '.' ~ node.name,
+            true
         ) %}
+        {% set target_columns = [] %}
+        {% for target in null_anomaly_targets %}
+            {% if target.model_id == model_id and target.column_name not in target_columns %}
+                {% do target_columns.append(target.column_name) %}
+            {% endif %}
+        {% endfor %}
 
-        {% if rel is not none %}
-            {% set columns = adapter.get_columns_in_relation(rel) %}
-            {% for col in columns %}
-                {% set query_part %}
+        {% if target_columns | length > 0 %}
+            {% set rel = adapter.get_relation(
+                database=node.database,
+                schema=node.schema,
+                identifier=node.alias or node.name
+            ) %}
+
+            {% if rel is not none %}
+                {% set columns = adapter.get_columns_in_relation(rel) %}
+                {% for col in columns %}
+                    {% set is_target = namespace(found=false) %}
+                    {% for target_column in target_columns %}
+                        {% if col.name == target_column or col.name | lower == target_column | lower %}
+                            {% set is_target.found = true %}
+                        {% endif %}
+                    {% endfor %}
+
+                    {% if is_target.found %}
+                        {% set query_part %}
 select
     '{{ node.name }}' as table_name,
     '{{ col.name }}' as column_name,
@@ -50,9 +120,11 @@ select
         else 0
     end as null_rate,
     {{ dbt.current_timestamp() }} as measured_at
-                {% endset %}
-                {% do queries.append(query_part) %}
-            {% endfor %}
+                        {% endset %}
+                        {% do queries.append(query_part) %}
+                    {% endif %}
+                {% endfor %}
+            {% endif %}
         {% endif %}
     {% endif %}
 {% endfor %}

--- a/tests/test_dbt_column_metrics.py
+++ b/tests/test_dbt_column_metrics.py
@@ -1,0 +1,332 @@
+"""Deterministic rendering tests for the native dbt column metrics model."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+
+from jinja2 import Environment
+
+MODEL_SQL = (
+    Path(__file__).parents[1] / "models" / "scherlok_column_metrics.sql"
+).read_text(encoding="utf-8")
+
+
+@dataclass
+class FakeColumn:
+    name: str
+    dtype: str
+
+
+@dataclass
+class FakeRelation:
+    identifier: str
+
+    def __str__(self) -> str:
+        return f'"warehouse"."public"."{self.identifier}"'
+
+
+class FakeAdapter:
+    def __init__(self, columns_by_identifier: dict[str, list[FakeColumn]]) -> None:
+        self.columns_by_identifier = columns_by_identifier
+        self.relation_calls: list[str] = []
+        self.column_calls: list[str] = []
+
+    def get_relation(self, *, database: str, schema: str, identifier: str) -> FakeRelation:
+        self.relation_calls.append(identifier)
+        return FakeRelation(identifier)
+
+    def get_columns_in_relation(self, relation: FakeRelation) -> list[FakeColumn]:
+        self.column_calls.append(relation.identifier)
+        return self.columns_by_identifier[relation.identifier]
+
+    @staticmethod
+    def quote(name: str) -> str:
+        return f'"{name}"'
+
+
+class FakeDbt:
+    @staticmethod
+    def type_float() -> str:
+        return "double"
+
+    @staticmethod
+    def type_string() -> str:
+        return "varchar"
+
+    @staticmethod
+    def current_timestamp() -> str:
+        return "current_timestamp"
+
+
+def model_node(name: str, package_name: str = "analytics") -> SimpleNamespace:
+    return SimpleNamespace(
+        resource_type="model",
+        package_name=package_name,
+        name=name,
+        unique_id=f"model.{package_name}.{name}",
+        database="warehouse",
+        schema="public",
+        alias=name,
+        config=SimpleNamespace(materialized="table"),
+    )
+
+
+def make_test_node(
+    name: str,
+    *,
+    attached_node: str | None = None,
+    column_name: str | None = None,
+    namespace: str | None = "scherlok",
+    package_name: str = "analytics",
+    dependency_ids: list[str] | None = None,
+    kwargs_column_name: str | None = None,
+) -> SimpleNamespace:
+    metadata_kwargs = {}
+    if kwargs_column_name is not None:
+        metadata_kwargs["column_name"] = kwargs_column_name
+
+    return SimpleNamespace(
+        resource_type="test",
+        package_name=package_name,
+        name=name,
+        unique_id=f"test.{package_name}.{name}",
+        test_metadata=SimpleNamespace(
+            name="null_anomaly",
+            namespace=namespace,
+            kwargs=metadata_kwargs,
+        ),
+        attached_node=attached_node,
+        column_name=column_name,
+        depends_on=SimpleNamespace(nodes=dependency_ids or []),
+    )
+
+
+def render_model(
+    nodes: list[SimpleNamespace],
+    columns_by_identifier: dict[str, list[FakeColumn]],
+    *,
+    include_only: list[str] | None = None,
+    exclude_models: list[str] | None = None,
+) -> tuple[str, FakeAdapter]:
+    adapter = FakeAdapter(columns_by_identifier)
+    environment = Environment(extensions=["jinja2.ext.do"])
+    environment.globals.update(
+        config=lambda **kwargs: "",
+        dbt=FakeDbt(),
+        none=None,
+    )
+
+    variables = {
+        "scherlok_include_models": include_only or [],
+        "scherlok_exclude_models": exclude_models or [],
+    }
+
+    rendered = environment.from_string(MODEL_SQL).render(
+        adapter=adapter,
+        graph=SimpleNamespace(
+            nodes={node.unique_id: node for node in nodes if hasattr(node, "unique_id")}
+        ),
+        dbt=FakeDbt(),
+        var=lambda name, default=None: variables.get(name, default),
+    )
+    return rendered, adapter
+
+
+def test_profiles_only_tested_columns_and_preserves_column_type() -> None:
+    orders = model_node("orders")
+    test = make_test_node(
+        "null_anomaly_orders_email",
+        attached_node=orders.unique_id,
+        column_name="email",
+    )
+
+    rendered, adapter = render_model(
+        [orders, test],
+        {
+            "orders": [
+                FakeColumn("id", "integer"),
+                FakeColumn("email", "text"),
+                FakeColumn("created_at", "timestamp"),
+            ]
+        },
+    )
+
+    assert adapter.relation_calls == ["orders"]
+    assert adapter.column_calls == ["orders"]
+    assert "'email' as column_name" in rendered
+    assert "'text' as column_type" in rendered
+    assert "'id' as column_name" not in rendered
+    assert "'created_at' as column_name" not in rendered
+
+
+def test_profiles_multiple_columns_and_ignores_unrelated_generic_tests() -> None:
+    orders = model_node("orders")
+    email_test = make_test_node(
+        "null_anomaly_orders_email",
+        attached_node=orders.unique_id,
+        column_name="email",
+    )
+    status_test = make_test_node(
+        "null_anomaly_orders_status",
+        attached_node=orders.unique_id,
+        column_name="status",
+    )
+    unrelated_test = make_test_node(
+        "not_null_orders_id",
+        attached_node=orders.unique_id,
+        column_name="id",
+    )
+    unrelated_test.test_metadata.name = "not_null_proportion"
+    other_package_test = make_test_node(
+        "other_null_anomaly_orders_id",
+        attached_node=orders.unique_id,
+        column_name="id",
+        namespace="other_package",
+    )
+
+    rendered, _ = render_model(
+        [orders, email_test, status_test, unrelated_test, other_package_test],
+        {
+            "orders": [
+                FakeColumn("id", "integer"),
+                FakeColumn("email", "text"),
+                FakeColumn("status", "text"),
+            ]
+        },
+    )
+
+    assert "'email' as column_name" in rendered
+    assert "'status' as column_name" in rendered
+    assert "'id' as column_name" not in rendered
+
+
+def test_duplicate_tests_do_not_duplicate_profiling() -> None:
+    orders = model_node("orders")
+    tests = [
+        make_test_node(
+            f"null_anomaly_orders_email_{suffix}",
+            attached_node=orders.unique_id,
+            column_name="email",
+        )
+        for suffix in ("one", "two")
+    ]
+
+    rendered, _ = render_model(
+        [orders, *tests],
+        {"orders": [FakeColumn("email", "text")]},
+    )
+
+    assert rendered.count("'email' as column_name") == 1
+
+
+def test_fallback_metadata_maps_test_to_its_model_and_column() -> None:
+    orders = model_node("orders")
+    metrics = model_node("scherlok_metrics", package_name="scherlok")
+    fallback_test = make_test_node(
+        "null_anomaly_orders_status",
+        column_name=None,
+        attached_node=None,
+        namespace=None,
+        package_name="scherlok",
+        dependency_ids=[orders.unique_id, metrics.unique_id],
+        kwargs_column_name="status",
+    )
+
+    rendered, adapter = render_model(
+        [orders, metrics, fallback_test],
+        {
+            "orders": [FakeColumn("id", "integer"), FakeColumn("status", "varchar")],
+            "scherlok_metrics": [FakeColumn("table_name", "varchar")],
+        },
+    )
+
+    assert adapter.relation_calls == ["orders"]
+    assert "'status' as column_name" in rendered
+    assert "'varchar' as column_type" in rendered
+
+
+def test_ambiguous_dependency_fallback_does_not_profile_a_model() -> None:
+    orders = model_node("orders")
+    customers = model_node("customers")
+    fallback_test = make_test_node(
+        "null_anomaly_ambiguous",
+        column_name=None,
+        attached_node=None,
+        dependency_ids=[orders.unique_id, customers.unique_id],
+        kwargs_column_name="email",
+    )
+
+    rendered, adapter = render_model(
+        [orders, customers, fallback_test],
+        {
+            "orders": [FakeColumn("email", "text")],
+            "customers": [FakeColumn("email", "text")],
+        },
+    )
+
+    assert adapter.relation_calls == []
+    assert "where 1 = 0" in rendered
+
+
+def test_model_without_null_anomaly_test_is_not_profiled() -> None:
+    orders = model_node("orders")
+    users = model_node("users")
+    test = make_test_node(
+        "null_anomaly_orders_email",
+        attached_node=orders.unique_id,
+        column_name="email",
+    )
+
+    _, adapter = render_model(
+        [orders, users, test],
+        {
+            "orders": [FakeColumn("email", "text")],
+            "users": [FakeColumn("email", "text")],
+        },
+    )
+
+    assert adapter.relation_calls == ["orders"]
+    assert adapter.column_calls == ["orders"]
+
+
+def test_include_and_exclude_filters_still_apply() -> None:
+    orders = model_node("orders")
+    users = model_node("users")
+    tests = [
+        make_test_node(
+            "null_anomaly_orders_email",
+            attached_node=orders.unique_id,
+            column_name="email",
+        ),
+        make_test_node(
+            "null_anomaly_users_email",
+            attached_node=users.unique_id,
+            column_name="email",
+        ),
+    ]
+    columns = {
+        "orders": [FakeColumn("email", "text")],
+        "users": [FakeColumn("email", "text")],
+    }
+
+    _, include_adapter = render_model(
+        [orders, users, *tests], columns, include_only=["orders"]
+    )
+    _, exclude_adapter = render_model(
+        [orders, users, *tests], columns, exclude_models=["orders"]
+    )
+
+    assert include_adapter.relation_calls == ["orders"]
+    assert exclude_adapter.relation_calls == ["users"]
+
+
+def test_empty_result_sql_is_preserved_when_no_columns_need_profiling() -> None:
+    orders = model_node("orders")
+
+    rendered, adapter = render_model(
+        [orders], {"orders": [FakeColumn("id", "integer")]}
+    )
+
+    assert adapter.relation_calls == []
+    assert "cast(null as varchar) as table_name" in rendered
+    assert "where 1 = 0" in rendered


### PR DESCRIPTION
Closes #71

## Summary

scherlok_column_metrics now profiles only columns that use scherlok.null_anomaly instead of scanning every physical column.

The implementation defensively handles dbt generic-test metadata across the supported dbt >=1.6,<2.0 range, including namespace/name matching, attached_node and depends_on fallbacks, duplicate-test deduplication, preserved include/exclude filters, case-insensitive physical-column matching, and adapter-provided column_type metadata.

Batching was intentionally left out to keep the change adapter-neutral. scherlok_column_metrics remains disabled by default.

## Validation

- 8 focused tests passed
- 366 passed, 24 skipped in the full suite
- ruff passed
- git diff --check passed