### PR TITLE
feat: add adaptive historical thresholds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Adaptive historical baselines** — after enough valid history, volume and column metric detectors learn per-metric variability with robust median/MAD bands; cold-start and unusable histories retain the existing fixed behavior. ([#62](https://github.com/rbmuller/scherlok/issues/62))
 - **`scherlok dbt-run-and-watch --output json`** — the wrapper now accepts the same `--output json` flag as `scherlok dbt`, so CI users get the wrapper's convenience and a machine-readable stdout payload in one step. `dbt run`'s own stdout is rerouted to stderr in JSON mode so it never mixes with the payload; if `dbt run` fails, stdout gets a small JSON error document (`project_dir`, `error`, `returncode`) instead of plain text. ([#47](https://github.com/rbmuller/scherlok/issues/47))
 - **Targeted `dbt-run-and-watch` profiling** — after a successful `dbt run`, the wrapper reads `target/run_results.json` and profiles only successful model nodes from that invocation. Missing or malformed artifacts fail clearly rather than falling back to the full manifest. ([#69](https://github.com/rbmuller/scherlok/issues/69))
 - **Exposure-aware dbt lineage in anomaly alerts** — downstream models remain identified separately from dbt exposures, whose labels and owner information are surfaced in the existing alert message without changing notification routing. ([#70](https://github.com/rbmuller/scherlok/issues/70))

--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ scherlok watch                                    # detect anomalies
 
 Three commands. Five minutes. Done.
 
+After five valid profiles, Scherlok learns per-metric variability from the
+latest 30 profiles using robust historical baselines for volume, numeric mean
+shifts, NULL rates, and distinct counts. During cold start or when history is
+not usable, it keeps the conservative fixed defaults.
+
 ## What It Catches
 
 | Anomaly | What Happened | Severity |

--- a/src/scherlok/detector/adaptive.py
+++ b/src/scherlok/detector/adaptive.py
@@ -1,0 +1,71 @@
+"""Robust statistics for adaptive anomaly baselines."""
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from itertools import islice
+from math import isfinite
+from numbers import Number
+from statistics import median
+
+ADAPTIVE_HISTORY_LIMIT = 30
+MIN_ADAPTIVE_SAMPLES = 5
+ADAPTIVE_SCORE_THRESHOLD = 3.0
+MAD_NORMALIZATION = 0.6745
+
+
+@dataclass(frozen=True)
+class AdaptiveBaseline:
+    """Median and scaled MAD for one historical metric."""
+
+    center: float
+    scale: float
+
+    def score(self, value: Number) -> float | None:
+        """Return the signed robust score for a finite numeric value."""
+        if isinstance(value, bool) or not isinstance(value, Number):
+            return None
+        try:
+            numeric_value = float(value)
+        except (TypeError, ValueError, OverflowError):
+            return None
+        if not isfinite(numeric_value):
+            return None
+        return (numeric_value - self.center) / self.scale
+
+
+def adaptive_baseline(
+    history: Iterable[Mapping[str, object]] | None,
+    metric: str,
+) -> AdaptiveBaseline | None:
+    """Build a robust baseline from the latest valid historical values.
+
+    The baseline is unavailable until five finite numeric observations exist,
+    or when the historical metric has no usable variation.
+    """
+    if history is None:
+        return None
+
+    values: list[float] = []
+    for profile in islice(history, ADAPTIVE_HISTORY_LIMIT):
+        if not isinstance(profile, Mapping):
+            continue
+        value = profile.get(metric)
+        if isinstance(value, bool) or not isinstance(value, Number):
+            continue
+        try:
+            numeric_value = float(value)
+        except (TypeError, ValueError, OverflowError):
+            continue
+        if isfinite(numeric_value):
+            values.append(numeric_value)
+
+    if len(values) < MIN_ADAPTIVE_SAMPLES:
+        return None
+
+    center = float(median(values))
+    mad = float(median(abs(value - center) for value in values))
+    scale = mad / MAD_NORMALIZATION
+    if not isfinite(scale) or scale <= 0:
+        return None
+
+    return AdaptiveBaseline(center=center, scale=scale)

--- a/src/scherlok/detector/anomaly.py
+++ b/src/scherlok/detector/anomaly.py
@@ -1,5 +1,8 @@
 """Z-score based anomaly detection for volume metrics."""
 
+from collections.abc import Sequence
+
+from scherlok.detector.adaptive import ADAPTIVE_SCORE_THRESHOLD, adaptive_baseline
 from scherlok.detector.severity import Severity, classify_volume_drop
 
 VOLUME_SPIKE_WARNING_PCT = 100  # 2x increase
@@ -18,6 +21,8 @@ def detect_volume_anomalies(
     current_profile: dict,
     stored_profile: dict,
     threshold: float = 3.0,
+    *,
+    history: Sequence[dict] | None = None,
 ) -> list[dict]:
     """Compare current volume against stored profile.
 
@@ -29,6 +34,73 @@ def detect_volume_anomalies(
     previous_count = stored_profile["row_count"]
 
     if previous_count == 0 and current_count == 0:
+        return anomalies
+
+    baseline = adaptive_baseline(history, "row_count")
+    if baseline is not None:
+        score = baseline.score(current_count)
+        if score is None or abs(score) <= ADAPTIVE_SCORE_THRESHOLD:
+            if previous_count > 0 and current_count == 0:
+                anomalies.append({
+                    "table": table,
+                    "type": "table_empty",
+                    "message": f"Table is now empty (was {previous_count:,} rows)",
+                    "severity": Severity.CRITICAL,
+                })
+            return anomalies
+
+        baseline_count = baseline.center
+        if current_count < baseline_count and baseline_count > 0:
+            change_pct = ((baseline_count - current_count) / baseline_count) * 100
+            severity = (
+                Severity.CRITICAL
+                if change_pct >= 50
+                else Severity.WARNING
+                if change_pct >= 20
+                else Severity.INFO
+            )
+            anomalies.append({
+                "table": table,
+                "type": "volume_drop",
+                "message": (
+                    f"Row count dropped {change_pct:.1f}% "
+                    f"(learned baseline {baseline_count:,.0f} -> {current_count:,}; "
+                    f"robust score: {score:+.2f})"
+                ),
+                "severity": severity,
+            })
+        elif current_count > baseline_count:
+            if baseline_count > 0:
+                change_pct = ((current_count - baseline_count) / baseline_count) * 100
+                severity = (
+                    Severity.CRITICAL
+                    if change_pct >= VOLUME_SPIKE_CRITICAL_PCT
+                    else Severity.WARNING
+                    if change_pct >= VOLUME_SPIKE_WARNING_PCT
+                    else Severity.INFO
+                )
+                effect = f"{change_pct:.0f}% change"
+            else:
+                severity = Severity.INFO
+                effect = "change from zero"
+            anomalies.append({
+                "table": table,
+                "type": "volume_spike",
+                "message": (
+                    f"Row count spiked ({effect}; learned baseline "
+                    f"{baseline_count:,.0f} -> {current_count:,}; "
+                    f"robust score: {score:+.2f})"
+                ),
+                "severity": severity,
+            })
+
+        if previous_count > 0 and current_count == 0:
+            anomalies.append({
+                "table": table,
+                "type": "table_empty",
+                "message": f"Table is now empty (was {previous_count:,} rows)",
+                "severity": Severity.CRITICAL,
+            })
         return anomalies
 
     # Detect drops

--- a/src/scherlok/detector/cardinality.py
+++ b/src/scherlok/detector/cardinality.py
@@ -1,5 +1,8 @@
 """Cardinality change detection — unexpected changes in distinct value counts."""
 
+from collections.abc import Sequence
+
+from scherlok.detector.adaptive import ADAPTIVE_SCORE_THRESHOLD, adaptive_baseline
 from scherlok.detector.severity import Severity
 
 # Percentage thresholds for cardinality change
@@ -12,6 +15,8 @@ def detect_cardinality_anomalies(
     column: str,
     current_dist: dict,
     stored_dist: dict,
+    *,
+    history: Sequence[dict] | None = None,
 ) -> list[dict]:
     """Compare current distinct count against stored profile for a column.
 
@@ -23,6 +28,36 @@ def detect_cardinality_anomalies(
     stored_card = stored_dist.get("distinct_count")
 
     if current_card is None or stored_card is None:
+        return anomalies
+
+    baseline = adaptive_baseline(history, "distinct_count")
+    if baseline is not None:
+        score = baseline.score(current_card)
+        if score is None or abs(score) <= ADAPTIVE_SCORE_THRESHOLD:
+            return anomalies
+
+        if baseline.center == 0:
+            change_pct = 0.0
+        else:
+            change_pct = abs(current_card - baseline.center) / baseline.center * 100
+        direction = "increased" if current_card > baseline.center else "decreased"
+        severity = (
+            Severity.CRITICAL
+            if change_pct >= CARDINALITY_CRITICAL_PCT
+            else Severity.WARNING
+            if change_pct >= CARDINALITY_WARNING_PCT
+            else Severity.INFO
+        )
+        anomalies.append({
+            "table": table,
+            "type": "cardinality_change",
+            "message": (
+                f"Column '{column}' distinct values {direction}: "
+                f"learned baseline {baseline.center:,.0f} -> {current_card:,} "
+                f"({change_pct:.0f}% change; robust score: {score:+.2f})"
+            ),
+            "severity": severity,
+        })
         return anomalies
 
     if stored_card == 0:

--- a/src/scherlok/detector/distribution_shift.py
+++ b/src/scherlok/detector/distribution_shift.py
@@ -1,5 +1,8 @@
 """Distribution shift detection — mean/stddev changes on numeric columns."""
 
+from collections.abc import Sequence
+
+from scherlok.detector.adaptive import ADAPTIVE_SCORE_THRESHOLD, adaptive_baseline
 from scherlok.detector.anomaly import z_score
 from scherlok.detector.severity import classify_distribution_shift
 
@@ -9,6 +12,8 @@ def detect_distribution_shift(
     column: str,
     current_dist: dict,
     stored_dist: dict,
+    *,
+    history: Sequence[dict] | None = None,
 ) -> list[dict]:
     """Compare current column distribution against stored profile.
 
@@ -22,7 +27,30 @@ def detect_distribution_shift(
     stored_stddev = stored_dist.get("stddev")
 
     # Only applies to numeric columns with valid stats
-    if current_mean is None or stored_mean is None or stored_stddev is None:
+    if current_mean is None:
+        return anomalies
+
+    baseline = adaptive_baseline(history, "mean")
+    if baseline is not None:
+        z = baseline.score(current_mean)
+        if z is None or abs(z) <= ADAPTIVE_SCORE_THRESHOLD:
+            return anomalies
+
+        severity = classify_distribution_shift(z)
+        direction = "increased" if z > 0 else "decreased"
+        anomalies.append({
+            "table": table,
+            "type": "distribution_shift",
+            "message": (
+                f"Column '{column}' mean {direction}: "
+                f"learned baseline {baseline.center:.4g} -> {current_mean:.4g} "
+                f"(robust score: {z:+.2f})"
+            ),
+            "severity": severity,
+        })
+        return anomalies
+
+    if stored_mean is None or stored_stddev is None:
         return anomalies
 
     z = z_score(current_mean, stored_mean, stored_stddev)

--- a/src/scherlok/detector/nullability.py
+++ b/src/scherlok/detector/nullability.py
@@ -1,5 +1,8 @@
 """Nullability anomaly detection — significant NULL rate changes per column."""
 
+from collections.abc import Sequence
+
+from scherlok.detector.adaptive import ADAPTIVE_SCORE_THRESHOLD, adaptive_baseline
 from scherlok.detector.severity import Severity
 
 # Absolute change thresholds for null_rate (0.0 to 1.0)
@@ -12,6 +15,8 @@ def detect_nullability_anomalies(
     column: str,
     current_dist: dict,
     stored_dist: dict,
+    *,
+    history: Sequence[dict] | None = None,
 ) -> list[dict]:
     """Compare current null rate against stored profile for a column.
 
@@ -23,6 +28,33 @@ def detect_nullability_anomalies(
     stored_rate = stored_dist.get("null_rate")
 
     if current_rate is None or stored_rate is None:
+        return anomalies
+
+    baseline = adaptive_baseline(history, "null_rate")
+    if baseline is not None:
+        score = baseline.score(current_rate)
+        if score is None or abs(score) <= ADAPTIVE_SCORE_THRESHOLD:
+            return anomalies
+
+        delta = abs(current_rate - baseline.center)
+        direction = "increased" if current_rate > baseline.center else "decreased"
+        severity = (
+            Severity.CRITICAL
+            if delta >= NULL_RATE_CRITICAL_DELTA
+            else Severity.WARNING
+            if delta >= NULL_RATE_WARNING_DELTA
+            else Severity.INFO
+        )
+        anomalies.append({
+            "table": table,
+            "type": "null_rate_change",
+            "message": (
+                f"Column '{column}' NULL rate {direction}: "
+                f"learned baseline {baseline.center:.1%} -> {current_rate:.1%} "
+                f"(Δ{delta:.1%}; robust score: {score:+.2f})"
+            ),
+            "severity": severity,
+        })
         return anomalies
 
     delta = abs(current_rate - stored_rate)

--- a/src/scherlok/service.py
+++ b/src/scherlok/service.py
@@ -41,9 +41,12 @@ def profile_and_detect(
     anomalies: list[dict] = []
 
     current_vol = profile_volume(connector, table)
+    volume_history = store.get_profile_history(table, "volume", days=None, limit=30)
     stored_vol = store.get_latest_profile(table, "volume")
     if stored_vol:
-        anomalies.extend(detect_volume_anomalies(table, current_vol, stored_vol))
+        anomalies.extend(
+            detect_volume_anomalies(table, current_vol, stored_vol, history=volume_history)
+        )
 
     current_sch = profile_schema(connector, table)
     stored_sch = store.get_latest_profile(table, "schema")
@@ -58,16 +61,25 @@ def profile_and_detect(
     for col in (current_sch or {}).get("columns", []):
         col_name = col["name"]
         current_dist = profile_distribution(connector, table, col_name)
+        distribution_history = store.get_profile_history(
+            table, f"distribution:{col_name}", days=None, limit=30
+        )
         stored_dist = store.get_latest_profile(table, f"distribution:{col_name}")
         if stored_dist:
             anomalies.extend(
-                detect_nullability_anomalies(table, col_name, current_dist, stored_dist)
+                detect_nullability_anomalies(
+                    table, col_name, current_dist, stored_dist, history=distribution_history
+                )
             )
             anomalies.extend(
-                detect_distribution_shift(table, col_name, current_dist, stored_dist)
+                detect_distribution_shift(
+                    table, col_name, current_dist, stored_dist, history=distribution_history
+                )
             )
             anomalies.extend(
-                detect_cardinality_anomalies(table, col_name, current_dist, stored_dist)
+                detect_cardinality_anomalies(
+                    table, col_name, current_dist, stored_dist, history=distribution_history
+                )
             )
         store.save_profile(table, f"distribution:{col_name}", current_dist)
 

--- a/src/scherlok/store/sqlite.py
+++ b/src/scherlok/store/sqlite.py
@@ -90,17 +90,26 @@ class ProfileStore:
         self,
         table_name: str,
         profile_type: str,
-        days: int = 30,
+        days: int | None = 30,
+        *,
+        limit: int | None = None,
     ) -> list[dict[str, Any]]:
-        """Get historical profiles for the last N days."""
-        cutoff = datetime.now(timezone.utc).isoformat()
-        rows = self._conn.execute(
+        """Get historical profiles, optionally bounded to the latest rows."""
+        query = (
             "SELECT data, created_at FROM profiles "
-            "WHERE table_name = ? AND profile_type = ? "
-            "AND created_at >= datetime(?, '-' || ? || ' days') "
-            "ORDER BY created_at DESC",
-            (table_name, profile_type, cutoff, days),
-        ).fetchall()
+            "WHERE table_name = ? AND profile_type = ?"
+        )
+        params: list[Any] = [table_name, profile_type]
+        if days is not None:
+            cutoff = datetime.now(timezone.utc).isoformat()
+            query += " AND created_at >= datetime(?, '-' || ? || ' days')"
+            params.extend([cutoff, days])
+        query += " ORDER BY created_at DESC"
+        if limit is not None:
+            query += " LIMIT ?"
+            params.append(limit)
+
+        rows = self._conn.execute(query, params).fetchall()
         return [
             {**json.loads(row["data"]), "_created_at": row["created_at"]}
             for row in rows

--- a/tests/test_adaptive.py
+++ b/tests/test_adaptive.py
@@ -1,0 +1,145 @@
+"""Tests for adaptive baselines and detector integration."""
+
+from math import inf, nan
+
+import pytest
+
+from scherlok.detector.adaptive import adaptive_baseline
+from scherlok.detector.anomaly import detect_volume_anomalies
+from scherlok.detector.cardinality import detect_cardinality_anomalies
+from scherlok.detector.distribution_shift import detect_distribution_shift
+from scherlok.detector.nullability import detect_nullability_anomalies
+from scherlok.detector.severity import Severity
+
+
+def _profiles(metric: str, values: list[object]) -> list[dict]:
+    return [{metric: value} for value in values]
+
+
+class TestAdaptiveBaseline:
+    def test_falls_back_with_too_few_valid_values(self):
+        history = _profiles("value", [1, 2, 3, 4, None, "5"])
+
+        assert adaptive_baseline(history, "value") is None
+
+    def test_calculates_median_and_scaled_mad(self):
+        baseline = adaptive_baseline(_profiles("value", [1, 2, 3, 4, 5]), "value")
+
+        assert baseline is not None
+        assert baseline.center == 3
+        assert baseline.scale == pytest.approx(1 / 0.6745)
+
+    def test_resists_a_historical_outlier(self):
+        baseline = adaptive_baseline(
+            _profiles("value", [9, 9, 10, 10, 10, 11, 1000]), "value"
+        )
+
+        assert baseline is not None
+        assert baseline.center == 10
+        assert baseline.scale == pytest.approx(1 / 0.6745)
+
+    def test_ignores_missing_non_numeric_and_non_finite_values(self):
+        history = _profiles("value", [None, "bad", nan, inf, 1, 2, 3, 4, 5])
+
+        baseline = adaptive_baseline(history, "value")
+
+        assert baseline is not None
+        assert baseline.center == 3
+
+    def test_falls_back_for_zero_mad(self):
+        assert adaptive_baseline(_profiles("value", [10, 10, 10, 10, 10]), "value") is None
+
+    def test_uses_only_the_latest_thirty_profiles(self):
+        values = [100] * 30 + [1, 2, 3, 4, 5]
+
+        baseline = adaptive_baseline(_profiles("value", values), "value")
+
+        assert baseline is None
+
+
+class TestAdaptiveDetectors:
+    def test_noisy_history_widens_volume_threshold(self):
+        current = {"row_count": 250}
+        stored = {"row_count": 100}
+        history = _profiles("row_count", [50, 100, 150, 100, 150, 50])
+
+        assert detect_volume_anomalies("t", current, stored)
+        assert detect_volume_anomalies("t", current, stored, history=history) == []
+
+    def test_small_statistically_unusual_volume_change_is_info(self):
+        history = _profiles("row_count", [98, 99, 100, 101, 102, 100])
+
+        anomalies = detect_volume_anomalies(
+            "t", {"row_count": 105}, {"row_count": 100}, history=history
+        )
+
+        assert len(anomalies) == 1
+        assert anomalies[0]["severity"] == Severity.INFO
+        assert "learned baseline" in anomalies[0]["message"]
+
+    @pytest.mark.parametrize(
+        ("current_count", "severity"),
+        [(250, Severity.WARNING), (500, Severity.CRITICAL)],
+    )
+    def test_volume_effect_size_severity_is_preserved(self, current_count, severity):
+        history = _profiles("row_count", [98, 99, 100, 101, 102, 100])
+
+        anomalies = detect_volume_anomalies(
+            "t", {"row_count": current_count}, {"row_count": 100}, history=history
+        )
+
+        assert anomalies[0]["severity"] == severity
+
+    def test_adaptive_distribution_uses_robust_sigma_and_never_critical(self):
+        history = _profiles("mean", [98, 99, 100, 101, 102, 100])
+
+        info = detect_distribution_shift(
+            "t", "col", {"mean": 105, "stddev": 0}, {"mean": 100, "stddev": 0},
+            history=history,
+        )
+        warning = detect_distribution_shift(
+            "t", "col", {"mean": 110, "stddev": 0}, {"mean": 100, "stddev": 0},
+            history=history,
+        )
+
+        assert info[0]["severity"] == Severity.INFO
+        assert warning[0]["severity"] == Severity.WARNING
+        assert warning[0]["severity"] != Severity.CRITICAL
+
+    def test_adaptive_nullability_preserves_effect_size_severity(self):
+        history = _profiles("null_rate", [0.01, 0.02, 0.03, 0.02, 0.01, 0.02])
+
+        anomalies = detect_nullability_anomalies(
+            "t", "col", {"null_rate": 0.15}, {"null_rate": 0.02}, history=history
+        )
+
+        assert anomalies[0]["severity"] == Severity.WARNING
+
+    def test_adaptive_cardinality_preserves_effect_size_severity(self):
+        history = _profiles("distinct_count", [98, 99, 100, 101, 102, 100])
+
+        anomalies = detect_cardinality_anomalies(
+            "t", "col", {"distinct_count": 500}, {"distinct_count": 100}, history=history
+        )
+
+        assert anomalies[0]["severity"] == Severity.CRITICAL
+
+    def test_table_empty_remains_critical(self):
+        history = _profiles("row_count", [98, 99, 100, 101, 102, 100])
+
+        anomalies = detect_volume_anomalies(
+            "t", {"row_count": 0}, {"row_count": 100}, history=history
+        )
+
+        empty = [anomaly for anomaly in anomalies if anomaly["type"] == "table_empty"]
+        assert len(empty) == 1
+        assert empty[0]["severity"] == Severity.CRITICAL
+
+    def test_insufficient_history_preserves_legacy_behavior(self):
+        current = {"row_count": 250}
+        stored = {"row_count": 100}
+        history = _profiles("row_count", [98, 99, 100, 101])
+
+        assert detect_volume_anomalies("t", current, stored, history=history) == (
+            detect_volume_anomalies("t", current, stored)
+        )

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,67 @@
+"""Tests for profile-and-detect orchestration."""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, call, patch
+
+from scherlok.service import profile_and_detect
+
+
+class FakeConnector:
+    def get_row_count(self, table):
+        return 100
+
+    def get_columns(self, table):
+        return [{"name": "id", "type": "integer", "nullable": False}]
+
+    def get_column_stats(self, table, column):
+        return {
+            "mean": 10,
+            "stddev": 1,
+            "min": 1,
+            "max": 20,
+            "null_count": 0,
+            "distinct_count": 100,
+        }
+
+    def get_last_modified(self, table):
+        return datetime.now(timezone.utc)
+
+
+def test_profile_and_detect_reads_and_reuses_distribution_history():
+    distribution_history = [{"mean": 10, "null_rate": 0, "distinct_count": 100}]
+    store = MagicMock()
+    store.get_profile_history.side_effect = [[], distribution_history]
+    store.get_latest_profile.side_effect = lambda table, profile_type: {
+        "volume": {"row_count": 100},
+        "distribution:id": {
+            "mean": 10,
+            "stddev": 1,
+            "null_rate": 0,
+            "distinct_count": 100,
+        },
+    }.get(profile_type)
+
+    with (
+        patch("scherlok.service.detect_volume_anomalies", return_value=[]) as volume,
+        patch("scherlok.service.detect_nullability_anomalies", return_value=[]) as nullability,
+        patch("scherlok.service.detect_distribution_shift", return_value=[]) as distribution,
+        patch("scherlok.service.detect_cardinality_anomalies", return_value=[]) as cardinality,
+    ):
+        profile_and_detect(FakeConnector(), store, "users")
+
+    assert store.get_profile_history.call_args_list == [
+        call("users", "volume", days=None, limit=30),
+        call("users", "distribution:id", days=None, limit=30),
+    ]
+    assert volume.call_args.kwargs["history"] == []
+    assert nullability.call_args.kwargs["history"] is distribution_history
+    assert distribution.call_args.kwargs["history"] is distribution_history
+    assert cardinality.call_args.kwargs["history"] is distribution_history
+    assert store.method_calls[0] == call.get_profile_history(
+        "users", "volume", days=None, limit=30
+    )
+    assert next(
+        index for index, item in enumerate(store.method_calls) if item[0] == "save_profile"
+    ) > 0
+    assert store.save_profile.call_args_list[0][0][:2] == ("users", "distribution:id")
+    assert store.save_profile.call_args_list[1][0][:2] == ("users", "volume")

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -62,6 +62,16 @@ class TestProfileStore:
         assert history[0]["row_count"] == 300  # most recent first
         store.close()
 
+    def test_profile_history_can_limit_latest_profiles_without_date_filter(self):
+        store = _temp_store()
+        for count in (100, 200, 300):
+            store.save_profile("users", "volume", {"row_count": count})
+
+        history = store.get_profile_history("users", "volume", days=None, limit=2)
+
+        assert [profile["row_count"] for profile in history] == [300, 200]
+        store.close()
+
     def test_save_and_get_anomalies(self):
         store = _temp_store()
         anomalies = [


### PR DESCRIPTION
## Summary

Implements the core history-aware thresholding slice of #62.

After five usable historical profiles, Scherlok now learns per-metric variability from the latest 30 profiles using a median + scaled-MAD baseline for:

* row count
* numeric-column mean
* NULL rate
* distinct count

Metrics with insufficient or degenerate history retain the existing fixed behavior.

## Design

* Uses existing `ProfileStore` history; no schema migration.
* Median provides the learned center.
* Scaled MAD provides a robust estimate of natural variation.
* Changes beyond 3 robust sigma become adaptive anomalies.
* Noisy metrics can therefore earn wider bands while stable metrics can surface smaller unusual changes.
* Existing WARNING/CRITICAL effect-size boundaries remain intact.
* Adaptive changes below existing WARNING thresholds surface as INFO.
* Distribution shift remains INFO/WARNING only and never becomes CRITICAL.
* `table_empty` remains CRITICAL regardless of adaptive history.
* Existing direct detector calls without history preserve legacy behavior.

The service reads volume history once per table and distribution history once per column, reusing the latter for mean, NULL-rate, and cardinality detection.

## Scope

This PR intentionally does not implement freshness cadence learning, seasonality, EWMA, manual overrides, dbt macro changes, migrations, or explainer schema changes. Those can remain follow-up work under #62.

Refs #62

## Validation

* Focused adaptive/detector/service/store tests: 68 passed
* Full suite: 383 passed, 24 skipped
* `ruff check src/ tests/`: passed
* `git diff --check`: passed