### PR TITLE
feat(cli): add --output json to status and history commands

### DIFF
--- a/src/scherlok/cli.py
+++ b/src/scherlok/cli.py
@@ -1297,70 +1297,130 @@ def report() -> None:
         print_profile_summary(table, vol, sch, fresh, anomaly_count=table_anomaly_count)
 
 
+def _table_health(
+    connector: object,
+    store: ProfileStore,
+    table: str,
+    vol: dict | None,
+    sch: dict | None,
+) -> str:
+    """Determine health status for one table via live anomaly check.
+
+    Returns 'healthy', 'warning', 'critical', or 'unknown' (not profiled).
+    """
+    if not vol:
+        return "unknown"
+    current_vol = profile_volume(connector, table)
+    current_sch = profile_schema(connector, table)
+    current_fresh = profile_freshness(connector, table)
+    stored_fresh = store.get_latest_profile(table, "freshness")
+    anomalies = detect_volume_anomalies(table, current_vol, vol)
+    anomalies.extend(detect_schema_drift(table, current_sch, sch))
+    if stored_fresh:
+        anomalies.extend(
+            detect_freshness_anomalies(table, current_fresh, stored_fresh)
+        )
+    if any(a["severity"].value == "CRITICAL" for a in anomalies):
+        return "critical"
+    if any(a["severity"].value == "WARNING" for a in anomalies):
+        return "warning"
+    return "healthy"
+
+
+_STATUS_RICH = {
+    "healthy": "[green]OK[/green]",
+    "warning": "[yellow]WARNING[/yellow]",
+    "critical": "[red]CRITICAL[/red]",
+    "unknown": "[yellow]Not profiled[/yellow]",
+}
+
+
 @app.command()
-def status() -> None:
+def status(
+    output: str = typer.Option(
+        "text", "--output",
+        help="Output format: 'text' (default) or 'json' for CI parsers",
+    ),
+) -> None:
     """Show health of monitored tables.
 
     Example:
         scherlok status
+        scherlok status --output json
     """
+    output_lower = output.lower()
+    if output_lower not in ("text", "json"):
+        console.print(
+            f"[red]Invalid --output value '{output}'. Use 'text' or 'json'.[/red]"
+        )
+        raise typer.Exit(code=1)
+    json_mode = output_lower == "json"
+
     store = ProfileStore()
     connector = _get_connector_or_exit()
     tables = connector.list_tables()
 
-    tbl = Table(title="Table Health")
-    tbl.add_column("Table", style="cyan")
-    tbl.add_column("Rows", justify="right")
-    tbl.add_column("Columns", justify="right")
-    tbl.add_column("Last Profiled")
-    tbl.add_column("Status")
-
+    records: list[dict] = []
     for table in tables:
         vol = store.get_latest_profile(table, "volume")
         sch = store.get_latest_profile(table, "schema")
+        records.append({
+            "table": table,
+            "rows": vol["row_count"] if vol else None,
+            "columns": len(sch["columns"]) if sch else None,
+            "status": _table_health(connector, store, table, vol, sch),
+            "last_profiled": vol.get("timestamp") if vol else None,
+        })
 
-        row_count = str(vol["row_count"]) if vol else "—"
-        col_count = str(len(sch["columns"])) if sch else "—"
-        last_profiled = vol.get("timestamp", "—") if vol else "—"
-
-        if not vol:
-            health = "[yellow]Not profiled[/yellow]"
-        else:
-            # Run quick anomaly check against current state
-            current_vol = profile_volume(connector, table)
-            current_sch = profile_schema(connector, table)
-            current_fresh = profile_freshness(connector, table)
-            stored_fresh = store.get_latest_profile(table, "freshness")
-            table_anomalies = detect_volume_anomalies(table, current_vol, vol)
-            table_anomalies.extend(detect_schema_drift(table, current_sch, sch))
-            if stored_fresh:
-                table_anomalies.extend(
-                    detect_freshness_anomalies(table, current_fresh, stored_fresh)
-                )
-            if any(a["severity"].value == "CRITICAL" for a in table_anomalies):
-                health = "[red]CRITICAL[/red]"
-            elif any(a["severity"].value == "WARNING" for a in table_anomalies):
-                health = "[yellow]WARNING[/yellow]"
-            else:
-                health = "[green]OK[/green]"
-
-        tbl.add_row(table, row_count, col_count, str(last_profiled), health)
-
-    console.print(tbl)
+    if json_mode:
+        print(json.dumps(records))
+    else:
+        tbl = Table(title="Table Health")
+        tbl.add_column("Table", style="cyan")
+        tbl.add_column("Rows", justify="right")
+        tbl.add_column("Columns", justify="right")
+        tbl.add_column("Last Profiled")
+        tbl.add_column("Status")
+        for r in records:
+            tbl.add_row(
+                r["table"],
+                str(r["rows"]) if r["rows"] is not None else "—",
+                str(r["columns"]) if r["columns"] is not None else "—",
+                r["last_profiled"] or "—",
+                _STATUS_RICH[r["status"]],
+            )
+        console.print(tbl)
 
 
 @app.command()
 def history(
     days: int = typer.Option(30, "--days", "-d", help="Number of days to look back"),
+    output: str = typer.Option(
+        "text", "--output",
+        help="Output format: 'text' (default) or 'json' for CI parsers",
+    ),
 ) -> None:
     """Show timeline of detected anomalies.
 
     Example:
         scherlok history
         scherlok history --days 7
+        scherlok history --output json
     """
+    output_lower = output.lower()
+    if output_lower not in ("text", "json"):
+        console.print(
+            f"[red]Invalid --output value '{output}'. Use 'text' or 'json'.[/red]"
+        )
+        raise typer.Exit(code=1)
+    json_mode = output_lower == "json"
+
     store = ProfileStore()
     records = store.get_anomaly_history(days=days)
+
+    if json_mode:
+        print(json.dumps(records))
+        return
 
     if not records:
         console.print(f"[green]No anomalies in the last {days} days.[/green]")

--- a/src/scherlok/cli.py
+++ b/src/scherlok/cli.py
@@ -1356,40 +1356,51 @@ def status(
         raise typer.Exit(code=1)
     json_mode = output_lower == "json"
 
-    store = ProfileStore()
-    connector = _get_connector_or_exit()
-    tables = connector.list_tables()
-
-    records: list[dict] = []
-    for table in tables:
-        vol = store.get_latest_profile(table, "volume")
-        sch = store.get_latest_profile(table, "schema")
-        records.append({
-            "table": table,
-            "rows": vol["row_count"] if vol else None,
-            "columns": len(sch["columns"]) if sch else None,
-            "status": _table_health(connector, store, table, vol, sch),
-            "last_profiled": vol.get("timestamp") if vol else None,
-        })
-
+    from scherlok.output import set_stderr, set_verbosity
+    prev_quiet = is_quiet()
     if json_mode:
-        print(json.dumps(records))
-    else:
-        tbl = Table(title="Table Health")
-        tbl.add_column("Table", style="cyan")
-        tbl.add_column("Rows", justify="right")
-        tbl.add_column("Columns", justify="right")
-        tbl.add_column("Last Profiled")
-        tbl.add_column("Status")
-        for r in records:
-            tbl.add_row(
-                r["table"],
-                str(r["rows"]) if r["rows"] is not None else "—",
-                str(r["columns"]) if r["columns"] is not None else "—",
-                r["last_profiled"] or "—",
-                _STATUS_RICH[r["status"]],
-            )
-        console.print(tbl)
+        set_stderr(True)
+        set_verbosity(quiet=True)
+
+    try:
+        store = ProfileStore()
+        connector = _get_connector_or_exit()
+        tables = connector.list_tables()
+
+        records: list[dict] = []
+        for table in tables:
+            vol = store.get_latest_profile(table, "volume")
+            sch = store.get_latest_profile(table, "schema")
+            records.append({
+                "table": table,
+                "rows": vol["row_count"] if vol else None,
+                "columns": len(sch["columns"]) if sch else None,
+                "status": _table_health(connector, store, table, vol, sch),
+                "last_profiled": vol.get("timestamp") if vol else None,
+            })
+
+        if json_mode:
+            print(json.dumps(records))
+        else:
+            tbl = Table(title="Table Health")
+            tbl.add_column("Table", style="cyan")
+            tbl.add_column("Rows", justify="right")
+            tbl.add_column("Columns", justify="right")
+            tbl.add_column("Last Profiled")
+            tbl.add_column("Status")
+            for r in records:
+                tbl.add_row(
+                    r["table"],
+                    str(r["rows"]) if r["rows"] is not None else "—",
+                    str(r["columns"]) if r["columns"] is not None else "—",
+                    r["last_profiled"] or "—",
+                    _STATUS_RICH[r["status"]],
+                )
+            console.print(tbl)
+    finally:
+        if json_mode:
+            set_stderr(False)
+            set_verbosity(quiet=prev_quiet)
 
 
 @app.command()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -138,13 +138,13 @@ def test_status_help():
     """Test that status command has help text."""
     result = runner.invoke(app, ["status", "--help"])
     assert result.exit_code == 0
-    assert "--output" in result.output
+    assert "--output" in ANSI_RE.sub("", result.output)
 
 
 def test_history_help_shows_output_flag():
     result = runner.invoke(app, ["history", "--help"])
     assert result.exit_code == 0
-    assert "--output" in result.output
+    assert "--output" in ANSI_RE.sub("", result.output)
 
 
 def _mock_connector(tables=None, row_count=100, columns=None):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,8 @@
 """Tests for the Scherlok CLI."""
 
+import json
 import re
+from unittest.mock import MagicMock, patch
 
 from typer.testing import CliRunner
 
@@ -136,3 +138,190 @@ def test_status_help():
     """Test that status command has help text."""
     result = runner.invoke(app, ["status", "--help"])
     assert result.exit_code == 0
+    assert "--output" in result.output
+
+
+def test_history_help_shows_output_flag():
+    result = runner.invoke(app, ["history", "--help"])
+    assert result.exit_code == 0
+    assert "--output" in result.output
+
+
+def _mock_connector(tables=None, row_count=100, columns=None):
+    c = MagicMock()
+    c.list_tables.return_value = tables or ["users"]
+    c.get_row_count.return_value = row_count
+    c.get_columns.return_value = columns or [
+        {"name": "id", "type": "integer", "nullable": False},
+    ]
+    c.get_last_modified.return_value = None
+    return c
+
+
+class TestStatusJson:
+    def test_produces_valid_json_array(self):
+        connector = _mock_connector()
+        with (
+            patch("scherlok.cli._get_connector_or_exit", return_value=connector),
+            patch("scherlok.cli.ProfileStore") as mock_store_cls,
+            patch("scherlok.cli._table_health", return_value="healthy"),
+        ):
+            store = MagicMock()
+            mock_store_cls.return_value = store
+            store.get_latest_profile.side_effect = lambda _t, pt: {
+                "volume": {"row_count": 100, "timestamp": "2026-08-31T12:00:00+00:00"},
+                "schema": {"columns": [{"name": "id"}]},
+            }.get(pt)
+
+            result = runner.invoke(app, ["status", "--output", "json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+        assert len(data) == 1
+        assert data[0] == {
+            "table": "users",
+            "rows": 100,
+            "columns": 1,
+            "status": "healthy",
+            "last_profiled": "2026-08-31T12:00:00+00:00",
+        }
+
+    def test_unprofiled_table_has_null_fields(self):
+        connector = _mock_connector()
+        with (
+            patch("scherlok.cli._get_connector_or_exit", return_value=connector),
+            patch("scherlok.cli.ProfileStore") as mock_store_cls,
+            patch("scherlok.cli._table_health", return_value="unknown"),
+        ):
+            store = MagicMock()
+            mock_store_cls.return_value = store
+            store.get_latest_profile.return_value = None
+
+            result = runner.invoke(app, ["status", "--output", "json"])
+
+        data = json.loads(result.output)
+        assert data[0]["rows"] is None
+        assert data[0]["columns"] is None
+        assert data[0]["last_profiled"] is None
+        assert data[0]["status"] == "unknown"
+
+    def test_multiple_tables(self):
+        connector = _mock_connector(tables=["orders", "users"])
+        with (
+            patch("scherlok.cli._get_connector_or_exit", return_value=connector),
+            patch("scherlok.cli.ProfileStore") as mock_store_cls,
+            patch("scherlok.cli._table_health", side_effect=["critical", "healthy"]),
+        ):
+            store = MagicMock()
+            mock_store_cls.return_value = store
+            store.get_latest_profile.side_effect = lambda _t, pt: {
+                "volume": {"row_count": 50, "timestamp": "2026-08-30T00:00:00+00:00"},
+                "schema": {"columns": [{"name": "id"}, {"name": "name"}]},
+            }.get(pt)
+
+            result = runner.invoke(app, ["status", "--output", "json"])
+
+        data = json.loads(result.output)
+        assert len(data) == 2
+        assert data[0]["table"] == "orders"
+        assert data[0]["status"] == "critical"
+        assert data[1]["table"] == "users"
+        assert data[1]["status"] == "healthy"
+
+    def test_text_mode_still_works(self):
+        connector = _mock_connector()
+        with (
+            patch("scherlok.cli._get_connector_or_exit", return_value=connector),
+            patch("scherlok.cli.ProfileStore") as mock_store_cls,
+            patch("scherlok.cli._table_health", return_value="healthy"),
+        ):
+            store = MagicMock()
+            mock_store_cls.return_value = store
+            store.get_latest_profile.side_effect = lambda _t, pt: {
+                "volume": {"row_count": 100, "timestamp": "2026-08-31T12:00:00+00:00"},
+                "schema": {"columns": [{"name": "id"}]},
+            }.get(pt)
+
+            result = runner.invoke(app, ["status"])
+
+        assert result.exit_code == 0
+        output = ANSI_RE.sub("", result.output)
+        assert "Table Health" in output
+        assert "users" in output
+
+    def test_invalid_output_value_exits_1(self):
+        result = runner.invoke(app, ["status", "--output", "xml"])
+        assert result.exit_code == 1
+
+
+class TestHistoryJson:
+    def test_produces_valid_json_array(self):
+        with patch("scherlok.cli.ProfileStore") as mock_store_cls:
+            store = MagicMock()
+            mock_store_cls.return_value = store
+            store.get_anomaly_history.return_value = [
+                {
+                    "table": "users",
+                    "type": "volume_drop",
+                    "severity": "CRITICAL",
+                    "message": "Row count dropped 50%",
+                    "detected_at": "2026-08-31T00:00:00+00:00",
+                },
+            ]
+
+            result = runner.invoke(app, ["history", "--output", "json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert len(data) == 1
+        assert data[0]["severity"] == "CRITICAL"
+        assert data[0]["table"] == "users"
+        assert data[0]["type"] == "volume_drop"
+        assert data[0]["detected_at"] == "2026-08-31T00:00:00+00:00"
+
+    def test_empty_history_returns_empty_array(self):
+        with patch("scherlok.cli.ProfileStore") as mock_store_cls:
+            store = MagicMock()
+            mock_store_cls.return_value = store
+            store.get_anomaly_history.return_value = []
+
+            result = runner.invoke(app, ["history", "--output", "json"])
+
+        assert result.exit_code == 0
+        assert json.loads(result.output) == []
+
+    def test_respects_days_flag(self):
+        with patch("scherlok.cli.ProfileStore") as mock_store_cls:
+            store = MagicMock()
+            mock_store_cls.return_value = store
+            store.get_anomaly_history.return_value = []
+
+            runner.invoke(app, ["history", "--days", "7", "--output", "json"])
+
+        store.get_anomaly_history.assert_called_once_with(days=7)
+
+    def test_text_mode_still_works(self):
+        with patch("scherlok.cli.ProfileStore") as mock_store_cls:
+            store = MagicMock()
+            mock_store_cls.return_value = store
+            store.get_anomaly_history.return_value = [
+                {
+                    "table": "users",
+                    "type": "volume_drop",
+                    "severity": "CRITICAL",
+                    "message": "Row count dropped",
+                    "detected_at": "2026-08-31T12:00:00+00:00",
+                },
+            ]
+
+            result = runner.invoke(app, ["history"])
+
+        assert result.exit_code == 0
+        output = ANSI_RE.sub("", result.output)
+        assert "Anomaly History" in output
+        assert "users" in output
+
+    def test_invalid_output_value_exits_1(self):
+        result = runner.invoke(app, ["history", "--output", "xml"])
+        assert result.exit_code == 1


### PR DESCRIPTION
## Summary

- **`scherlok status --output json`** — emits a JSON array of table health objects (`table`, `rows`, `columns`, `status`, `last_profiled`), matching the contract from #14
- **`scherlok history --output json`** — emits a JSON array of anomaly records (`detected_at`, `severity`, `table`, `type`, `message`), matching the contract from #15
- Extracts `_table_health()` helper to share health-determination logic between text and JSON paths
- Follows the existing `--output text|json` pattern from `scherlok dbt`

## Validation

- 23 CLI tests passed (11 new), full suite 424 passed
- `ruff check src tests`: passed

Closes #14, closes #15.